### PR TITLE
Strip spaces in comma separated attributes

### DIFF
--- a/signals/parser/api.py
+++ b/signals/parser/api.py
@@ -22,7 +22,7 @@ class API(object):
         meta = endpoint_json.get('#meta')
         if meta:
             for authorization_attribute in meta.split(","):
-                self.process_authorization_attribute(authorization_attribute)
+                self.process_authorization_attribute(authorization_attribute.strip())
 
     def process_authorization_attribute(self, attribute):
         if attribute == Field.OPTIONAL:

--- a/signals/parser/schema.py
+++ b/signals/parser/schema.py
@@ -38,7 +38,7 @@ class DataObject(object):
             self.create_field(field_name, field_attributes)
 
     def create_field(self, field_name, field_attributes):
-        field_attributes = field_attributes.split(",")
+        field_attributes = [field_attribute.strip() for field_attribute in field_attributes.split(",")]
         if Relationship.is_relationship(field_attributes):
             self.relationships.append(Relationship(field_name, field_attributes))
         else:

--- a/tests/parser/test_api.py
+++ b/tests/parser/test_api.py
@@ -19,7 +19,7 @@ class APITestCase(unittest.TestCase):
         api = API("user/", {})
         self.assertIsNone(api.authorization)
 
-        api.set_authorization({"#meta": "basicauth,optional"})
+        api.set_authorization({"#meta": "basicauth, optional"})
 
         self.assertTrue(api.authorization_optional)
         self.assertEqual(api.authorization, API.BASIC_AUTH)

--- a/tests/parser/test_schema.py
+++ b/tests/parser/test_schema.py
@@ -54,16 +54,20 @@ class SchemaTestCase(unittest.TestCase):
     def test_create_field(self):
         data_object = DataObject("$testRequest", {})
         self.assertEqual(data_object.fields, [])
-        data_object.create_field("username", "string")
+        data_object.create_field("username", "string, optional")
         self.assertEqual(len(data_object.fields), 1)
         self.assertEqual(data_object.fields[0].name, "username")
+        self.assertEqual(data_object.fields[0].field_type, "string")
+        self.assertEqual(data_object.fields[0].optional, True)
 
     def test_create_relationship(self):
         data_object = DataObject("$testRequest", {})
         self.assertEqual(data_object.relationships, [])
-        data_object.create_field("messages", "O2M,$messageResponse")
+        data_object.create_field("messages", "O2M, $messageResponse")
         self.assertEqual(len(data_object.relationships), 1)
         self.assertEqual(data_object.relationships[0].name, "messages")
+        self.assertEqual(data_object.relationships[0].relationship_type, "O2M")
+        self.assertEqual(data_object.relationships[0].related_object, "$messageResponse")
 
     def test_empty_data_object_properties(self):
         data_object = DataObject("$testRequest", {})


### PR DESCRIPTION
@baylee @rmutter Removes the surrounding whitespace of each attribute before it's processed. This lets you have spaces in your comma separated list of attributes.