### PR TITLE
adding trailing slash to api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ target/
 code/
 tests/files/DataModel.h
 tests/files/DataModel.m
+
+# DS Store
+.DS_Store

--- a/signals/main.py
+++ b/signals/main.py
@@ -13,6 +13,10 @@ generators = {
 # Issues unit testing `main` due to click decorators.
 def run_main(schema, generator_name, data_models, core_data, project_name, api_url, save):
     schema = Schema(schema)
+
+    if not api_url.endswith('/'):
+        api_url += '/'
+
     generator = generators[generator_name](schema, data_models, core_data, project_name, api_url)
     try:
         generator.process()

--- a/signals/main.py
+++ b/signals/main.py
@@ -14,9 +14,6 @@ generators = {
 def run_main(schema, generator_name, data_models, core_data, project_name, api_url, save):
     schema = Schema(schema)
 
-    if not api_url.endswith('/'):
-        api_url += '/'
-
     generator = generators[generator_name](schema, data_models, core_data, project_name, api_url)
     try:
         generator.process()
@@ -50,6 +47,13 @@ def project_specified(ctx, param, value):
         ctx.exit()
 
 
+def add_trailing_slash_to_api(ctx, param, value):
+    if not value.endswith('/'):
+        value += '/'
+
+    return value
+
+
 @click.command()
 @click.option('settings_path', '--settingspath',
               help='The project path where Signals should look for a .signalsconfig file.  If specified, the contents'
@@ -80,7 +84,8 @@ def project_specified(ctx, param, value):
               prompt='the string url of your api or a method call that returns it',
               help='The fully qualified url of your API for making calls or a method that will return the API, '
                    'ex. Constants.getAPIURL()',
-              type=click.STRING)
+              type=click.STRING,
+              callback=add_trailing_slash_to_api)
 @click.option('--save', is_flag=True)
 # TODO: These are iOS specific settings and we'll need to figure out a way to handle generator specific arguments
 # when we add more generators in the future.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 import mock
 import unittest
 import subprocess
-from signals.main import run_main
+from signals.main import run_main, add_trailing_slash_to_api
 from tests.utils import captured_stderr, captured_stdout
 
 
@@ -28,3 +28,13 @@ class MainTestCase(unittest.TestCase):
             run_main("./tests/files/test_schema.json", "ios", "./tests/files/", "./core/data/path", "YetiProject",
                      "http://test.com/api/v1/", False)
             self.assertIn("Must quit Xcode before writing to core data", out.getvalue())
+
+    def test_add_trailing_slash_to_api(self):
+        url_no_slash = 'http://test.com'
+        url_with_slash = add_trailing_slash_to_api(None, None, url_no_slash)
+        # '/' has been added to the url string if it did not end in a slash
+        self.assertEqual(url_with_slash, 'http://test.com/')
+
+        same_url = add_trailing_slash_to_api(None, None, url_with_slash)
+        # '/' has not been added to the url string if it already ended in a slash
+        self.assertEqual(same_url, 'http://test.com/')


### PR DESCRIPTION
@rmutter @baylee 
Adding a trailing slash to api_url if there is none, re: https://github.com/yeti/signals/issues/40