### PR TITLE
Data model setup check #39

### DIFF
--- a/signals/helpers.py
+++ b/signals/helpers.py
@@ -1,0 +1,16 @@
+import os.path
+import glob
+
+
+def recursively_find_parent_containing_file(current_path, search_files):
+    # Convert to absolute path, in case we received relative path
+    current_path = os.path.abspath(current_path)
+    while current_path != os.sep:
+        for current_file in search_files:
+            # Check if this path has any of the files we're looking for
+            if len(glob.glob(current_path + os.sep + current_file)) > 0:
+                return current_path
+
+        current_path = os.path.normpath(os.path.join(current_path, ".."))
+
+    return None

--- a/signals/helpers.py
+++ b/signals/helpers.py
@@ -9,7 +9,7 @@ def recursively_find_parent_containing_file(current_path, search_files):
         for current_file in search_files:
             # Check if this path has any of the files we're looking for
             if len(glob.glob(current_path + os.sep + current_file)) > 0:
-                return current_path
+                return current_path, current_file
 
         current_path = os.path.normpath(os.path.join(current_path, ".."))
 

--- a/signals/settings.py
+++ b/signals/settings.py
@@ -1,6 +1,7 @@
 from signals.logging import SignalsError, progress
 import os.path
-import glob
+
+import helpers
 
 
 def load_settings(settings_path):
@@ -40,17 +41,13 @@ def find_project_root(paths):
         if current_path is None or len(current_path) == 0:
             continue
 
-        # Convert to absolute path, in case we received relative path from user
-        current_path = os.path.abspath(current_path)
-        while current_path != os.sep:
-            # Check if this path has the .xcodeproj or .xcworkspace files
-            if len(glob.glob(current_path + os.sep + "*.xcodeproj")) > 0:
-                return current_path
-            if len(glob.glob(current_path + os.sep + "*.xcworkspace")) > 0:
-                return current_path
+        parent_path_containing_target = helpers.recursively_find_parent_containing_file(current_path, ["dummyfile",
+                                                                                                       "*.xcodeproj",
+                                                                                                       "*.xcworkspace"])
+        if parent_path_containing_target is not None:
+            return parent_path_containing_target
 
-            current_path = os.path.normpath(os.path.join(current_path, ".."))
-    return
+    return None
 
 
 def output_settings(project_root, schema, generator_name, data_models, core_data, project_name, api_url):

--- a/signals/settings.py
+++ b/signals/settings.py
@@ -41,9 +41,9 @@ def find_project_root(paths):
         if current_path is None or len(current_path) == 0:
             continue
 
-        parent_path_containing_target = helpers.recursively_find_parent_containing_file(current_path, ["dummyfile",
-                                                                                                       "*.xcodeproj",
-                                                                                                       "*.xcworkspace"])
+        parent_path_containing_target, filename = helpers.recursively_find_parent_containing_file(current_path,
+                                                                                                  ["*.xcodeproj",
+                                                                                                   "*.xcworkspace"])
         if parent_path_containing_target is not None:
             return parent_path_containing_target
 

--- a/tests/files/AppDelegate.swift
+++ b/tests/files/AppDelegate.swift
@@ -1,0 +1,58 @@
+//
+//  AppDelegate.swift
+//  FinjanFileBrowser
+//
+//  Created by Lee McDole on 8/11/15.
+//  Copyright (c) 2015 Yeti. All rights reserved.
+//
+
+import UIKit
+import CoreData
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+  var window: UIWindow?
+  let appDependencies = AppDependencies()
+
+
+  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    // Override point for customization after application launch.
+    
+    appDependencies.installViewControllersIntoWindow(window!)
+    
+    // Core Data / RestKit setup
+    DataModel.sharedDataModel().setup()
+    
+    // RestKit Logging
+    Logging.setup()
+    
+    
+    return true
+  }
+
+  func applicationWillResignActive(application: UIApplication) {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+  }
+
+  func applicationDidEnterBackground(application: UIApplication) {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+  }
+
+  func applicationWillEnterForeground(application: UIApplication) {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+  }
+
+  func applicationDidBecomeActive(application: UIApplication) {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+  }
+
+  func applicationWillTerminate(application: UIApplication) {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+  }
+
+
+}
+

--- a/tests/files/BadAppDelegate.swift
+++ b/tests/files/BadAppDelegate.swift
@@ -1,0 +1,57 @@
+//
+//  AppDelegate.swift
+//  FinjanFileBrowser
+//
+//  Created by Lee McDole on 8/11/15.
+//  Copyright (c) 2015 Yeti. All rights reserved.
+//
+
+import UIKit
+import CoreData
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+  var window: UIWindow?
+  let appDependencies = AppDependencies()
+
+
+  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    // Override point for customization after application launch.
+    
+    appDependencies.installViewControllersIntoWindow(window!)
+    
+    // Missing Core Data / Rest Kit setup call here!
+    
+    // RestKit Logging
+    Logging.setup()
+    
+    
+    return true
+  }
+
+  func applicationWillResignActive(application: UIApplication) {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+  }
+
+  func applicationDidEnterBackground(application: UIApplication) {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+  }
+
+  func applicationWillEnterForeground(application: UIApplication) {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+  }
+
+  func applicationDidBecomeActive(application: UIApplication) {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+  }
+
+  func applicationWillTerminate(application: UIApplication) {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+  }
+
+
+}
+

--- a/tests/generators/ios/test_ios_generator.py
+++ b/tests/generators/ios/test_ios_generator.py
@@ -5,6 +5,14 @@ from signals.logging import SignalsError
 from signals.parser.schema import Schema
 
 
+def good_app_delegate(var1, var2):
+    return "./tests/files", "AppDelegate.swift"
+
+
+def bad_app_delegate(var1, var2):
+    return "./tests/files", "BadAppDelegate.swift"
+
+
 class iOSGeneratorTestCase(unittest.TestCase):
     @mock.patch("signals.generators.ios.ios_generator.subprocess")
     def test_is_xcode_running(self, mock_subprocess):
@@ -21,3 +29,17 @@ class iOSGeneratorTestCase(unittest.TestCase):
         with self.assertRaises(SignalsError) as e:
             generator.process()
         self.assertEqual(e.exception.msg, "Must quit Xcode before writing to core data")
+
+    @mock.patch("signals.generators.ios.ios_generator.recursively_find_parent_containing_file", side_effect=good_app_delegate)
+    def test_check_setup_called_success(self, mock_function):
+        generator = iOSGenerator(Schema("./tests/files/test_schema.json"), "./tests/files/", "./core/data/path",
+                                 "YetiProject", "http://test.com/api/v1/")
+        self.assertTrue(generator.check_setup_called())
+
+    @mock.patch("signals.generators.ios.ios_generator.recursively_find_parent_containing_file", side_effect=bad_app_delegate)
+    def test_check_setup_called_failure(self, mock_function):
+        generator = iOSGenerator(Schema("./tests/files/test_schema.json"), "./tests/files/", "./core/data/path",
+                                 "YetiProject", "http://test.com/api/v1/")
+        self.assertFalse(generator.check_setup_called())
+
+


### PR DESCRIPTION
ios_generator now searches for an AppDelegate.swift file, and if it finds one in a parent directory of the data_models path, it opens the file and searches for the string "sharedDataModel().setup()".  If it's not found, it outputs a warning to the user.

Fixes #39 

@rmutter @baylee 