### PR TITLE
Issue #37: Deleting the signals_code folder after generator finishes

### DIFF
--- a/signals/generators/base/base_generator.py
+++ b/signals/generators/base/base_generator.py
@@ -1,10 +1,17 @@
+import os
+import shutil
 
 
 class BaseGenerator(object):
-    BUILD_DIR = "code"
+    BUILD_DIR = "signals_code"
 
     def __init__(self, schema):
         self.schema = schema
 
     def process(self):
         pass
+
+    @classmethod
+    def clear_generated_code_files(cls):
+        if os.path.isdir(cls.BUILD_DIR):
+            shutil.rmtree(cls.BUILD_DIR)

--- a/signals/main.py
+++ b/signals/main.py
@@ -25,8 +25,13 @@ def run_main(schema, generator_name, data_models, core_data, project_name, api_u
         print(str(e))
     else:
         progress('Finished generating your files!')
+    finally:
+        generator.clear_generated_code_files()
 
 
+#
+# Click command option callback functions:
+#
 def project_specified(ctx, param, value):
     if not value or (ctx is not None and ctx.resilient_parsing):
         return

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,10 @@
+import os
 import click
 import mock
 import unittest
 import subprocess
 from signals.main import run_main, add_trailing_slash_to_api, validate_schema_path
+from signals.generators.base.base_generator import BaseGenerator
 from tests.utils import captured_stderr, captured_stdout
 
 
@@ -29,6 +31,16 @@ class MainTestCase(unittest.TestCase):
             run_main("./tests/files/test_schema.json", "ios", "./tests/files/", "./core/data/path", "YetiProject",
                      "http://test.com/api/v1/", False)
             self.assertIn("Must quit Xcode before writing to core data", out.getvalue())
+
+    def test_clear_generated_code_files(self):
+        # Currently, a previous test is creating, but not deleting, this directory.
+        # Potentially could change in future, thus the check if BUILD_DIR exists.
+        if not os.path.exists(BaseGenerator.BUILD_DIR):
+            os.makedirs(BaseGenerator.BUILD_DIR)
+
+        self.assertTrue(os.path.isdir(BaseGenerator.BUILD_DIR))
+        BaseGenerator.clear_generated_code_files()
+        self.assertFalse(os.path.isdir(BaseGenerator.BUILD_DIR))
 
     #
     # Tests for command option callback functions:


### PR DESCRIPTION
@rmutter @baylee 

Not sure if I should mock the `os` methods, but since the `signals_code` directory is actually created, I thought it made more sense to actually check for the existences of the directory rather than to mock the methods and check that they were called.