### PR TITLE
Schema endpoint validation

### DIFF
--- a/signals/main.py
+++ b/signals/main.py
@@ -94,7 +94,6 @@ def validate_path(ctx, param, value):
               help='The location where you\'d like your iOS data model files stored.',
               type=click.Path(dir_okay=True),
               callback=validate_path)
-              # type=click.Path())
 @click.option('core_data', '--coredata',
               help='The location of your core data configuration xcdatamodel file.',
               type=click.Path(exists=True))

--- a/signals/main.py
+++ b/signals/main.py
@@ -60,14 +60,15 @@ def add_trailing_slash_to_api(ctx, param, value):
     return value
 
 
-def validate_schema_path(ctx, param, value):
+def validate_path(ctx, param, value):
     if value.startswith('~'):
         value = os.path.expanduser(value)
     elif value.startswith('.'):
         value = os.path.abspath(value)
 
-    if not os.path.isfile(value):
-        raise click.BadParameter("File doesn't exist.", ctx, param)
+    if not os.path.isfile(value) and not os.path.exists(value):
+        error_message = "{} does not exist.".format(value)
+        raise click.BadParameter(error_message, ctx, param)
     else:
         return value
 
@@ -83,7 +84,7 @@ def validate_schema_path(ctx, param, value):
               prompt='path to api schema file',
               help='The server\'s API schema file.',
               type=click.Path(file_okay=True),
-              callback=validate_schema_path)
+              callback=validate_path)
 @click.option('--generator',
               prompt='name of generator to use',
               help='The name of the generator you\'d like to use.',
@@ -91,7 +92,9 @@ def validate_schema_path(ctx, param, value):
 @click.option('data_models', '--datamodels',
               prompt='path to iOS data models',
               help='The location where you\'d like your iOS data model files stored.',
-              type=click.Path())
+              type=click.Path(dir_okay=True),
+              callback=validate_path)
+              # type=click.Path())
 @click.option('core_data', '--coredata',
               help='The location of your core data configuration xcdatamodel file.',
               type=click.Path(exists=True))

--- a/signals/parser/api.py
+++ b/signals/parser/api.py
@@ -63,13 +63,10 @@ class GetAPI(API):
 
 class RequestResponseAPI(API):
     def __init__(self, url_path, endpoint_json):
-        # self.validate(endpoint_json)
         super(RequestResponseAPI, self).__init__(url_path, endpoint_json)
         self.request_object = endpoint_json['request']  # exists?
         self.response_code = endpoint_json['response'].keys()[0]
         self.response_object = endpoint_json['response'][self.response_code]  # exists?
-        # print self.response_object
-        # print "done with request response api"
 
 
 class PostAPI(RequestResponseAPI):

--- a/signals/parser/api.py
+++ b/signals/parser/api.py
@@ -33,8 +33,9 @@ class API(object):
             error_message = "Found invalid authorization attribute: {} for {}, exiting."
             raise SignalsError(error_message.format(attribute, self.url_path))
 
-    # def validate
-        # given an object, see if it exists in the obj array, raise signals error
+    # def validate(self, endpoint_json):
+    #     print endpoint_json
+    #     print 'validate'
 
     # OR
         # each class has a method that returns an array of what to check
@@ -62,10 +63,13 @@ class GetAPI(API):
 
 class RequestResponseAPI(API):
     def __init__(self, url_path, endpoint_json):
+        # self.validate(endpoint_json)
         super(RequestResponseAPI, self).__init__(url_path, endpoint_json)
         self.request_object = endpoint_json['request']  # exists?
         self.response_code = endpoint_json['response'].keys()[0]
         self.response_object = endpoint_json['response'][self.response_code]  # exists?
+        # print self.response_object
+        # print "done with request response api"
 
 
 class PostAPI(RequestResponseAPI):
@@ -83,6 +87,3 @@ class PutAPI(RequestResponseAPI):
 class DeleteAPI(API):
     method = "delete"
 
-
-# to run, main.py, use test_schema.json, don't pass coredata flag, use a fake proj name,
-# put files somewhere easy to check

--- a/signals/parser/api.py
+++ b/signals/parser/api.py
@@ -33,6 +33,14 @@ class API(object):
             error_message = "Found invalid authorization attribute: {} for {}, exiting."
             raise SignalsError(error_message.format(attribute, self.url_path))
 
+    # def validate
+        # given an object, see if it exists in the obj array, raise signals error
+
+    # OR
+        # each class has a method that returns an array of what to check
+        # get the array and loop through and check if they all exist, raise error if not
+        # base method should just have an empty array
+
 
 class GetAPI(API):
     RESOURCE_DETAIL = "detail"
@@ -45,17 +53,19 @@ class GetAPI(API):
         default_resource_type = self.RESOURCE_DETAIL if ":id" in url_path else self.RESOURCE_LIST
         self.resource_type = endpoint_json.get('resource_type', default_resource_type)
 
-        self.parameters_object = endpoint_json.get('parameters')
+        self.parameters_object = endpoint_json.get('parameters')  # exists?
         self.response_code = endpoint_json['response'].keys()[0]
-        self.response_object = endpoint_json['response'][self.response_code]
+        self.response_object = endpoint_json['response'][self.response_code]  # exists?
+
+    # override API validate method
 
 
 class RequestResponseAPI(API):
     def __init__(self, url_path, endpoint_json):
         super(RequestResponseAPI, self).__init__(url_path, endpoint_json)
-        self.request_object = endpoint_json['request']
+        self.request_object = endpoint_json['request']  # exists?
         self.response_code = endpoint_json['response'].keys()[0]
-        self.response_object = endpoint_json['response'][self.response_code]
+        self.response_object = endpoint_json['response'][self.response_code]  # exists?
 
 
 class PostAPI(RequestResponseAPI):
@@ -72,3 +82,7 @@ class PutAPI(RequestResponseAPI):
 
 class DeleteAPI(API):
     method = "delete"
+
+
+# to run, main.py, use test_schema.json, don't pass coredata flag, use a fake proj name,
+# put files somewhere easy to check

--- a/signals/parser/api.py
+++ b/signals/parser/api.py
@@ -33,15 +33,6 @@ class API(object):
             error_message = "Found invalid authorization attribute: {} for {}, exiting."
             raise SignalsError(error_message.format(attribute, self.url_path))
 
-    # def validate(self, endpoint_json):
-    #     print endpoint_json
-    #     print 'validate'
-
-    # OR
-        # each class has a method that returns an array of what to check
-        # get the array and loop through and check if they all exist, raise error if not
-        # base method should just have an empty array
-
 
 class GetAPI(API):
     RESOURCE_DETAIL = "detail"
@@ -54,19 +45,17 @@ class GetAPI(API):
         default_resource_type = self.RESOURCE_DETAIL if ":id" in url_path else self.RESOURCE_LIST
         self.resource_type = endpoint_json.get('resource_type', default_resource_type)
 
-        self.parameters_object = endpoint_json.get('parameters')  # exists?
+        self.parameters_object = endpoint_json.get('parameters')
         self.response_code = endpoint_json['response'].keys()[0]
-        self.response_object = endpoint_json['response'][self.response_code]  # exists?
-
-    # override API validate method
+        self.response_object = endpoint_json['response'][self.response_code]
 
 
 class RequestResponseAPI(API):
     def __init__(self, url_path, endpoint_json):
         super(RequestResponseAPI, self).__init__(url_path, endpoint_json)
-        self.request_object = endpoint_json['request']  # exists?
+        self.request_object = endpoint_json['request']
         self.response_code = endpoint_json['response'].keys()[0]
-        self.response_object = endpoint_json['response'][self.response_code]  # exists?
+        self.response_object = endpoint_json['response'][self.response_code]
 
 
 class PostAPI(RequestResponseAPI):
@@ -83,4 +72,3 @@ class PutAPI(RequestResponseAPI):
 
 class DeleteAPI(API):
     method = "delete"
-

--- a/signals/parser/schema.py
+++ b/signals/parser/schema.py
@@ -29,24 +29,20 @@ class Schema(object):
             data_object = DataObject(object_name, data_object_json[object_name])
             self.data_objects[data_object.name] = data_object
 
-    # Note: Why do we call them "apis" in method names, but then call them "urls" in the schema/code
     def validate_apis_and_objects(self):
         for url in self.urls:
+            # Loop over endpoints for each url in the schema
             for endpoint in URL.URL_ENDPOINTS.keys():
+                schema_object_types = ['parameters_object', 'request_object', 'response_object']
                 api = getattr(url, endpoint, None)
+                # If there is a defined api endpoint, verify that all necessary objects are defined
                 if api:
-                    if getattr(api, 'parameters_object', None):
-                        if api.parameters_object not in self.data_objects:
-                            error = "{} doesn't exist in schema file".format(api.parameters_object)
-                            raise SignalsError(error)
-                    if getattr(api, 'request_object', None):
-                        if api.request_object not in self.data_objects:
-                            error = "{} doesn't exist in schema file".format(api.request_object)
-                            raise SignalsError(error)
-                    if getattr(api, 'response_object', None):
-                        if api.response_object not in self.data_objects:
-                            error = "{} doesn't exist in schema file".format(api.response_object)
-                            raise SignalsError(error)
+                    for schema_object_type in schema_object_types:
+                        api_schema_object = getattr(api, schema_object_type, None)
+                        if api_schema_object:
+                            if api_schema_object not in self.data_objects:
+                                error = "{} doesn't exist in schema file".format(api_schema_object)
+                                raise SignalsError(error)
 
 
 class DataObject(object):

--- a/signals/parser/schema.py
+++ b/signals/parser/schema.py
@@ -1,7 +1,7 @@
 import json
 from signals.parser.api import GetAPI, PostAPI, PutAPI, PatchAPI, DeleteAPI
 from signals.parser.fields import Relationship, Field
-from signals.logging import warn, progress
+from signals.logging import warn, progress, SignalsError
 
 __author__ = 'rudy'
 
@@ -17,6 +17,44 @@ class Schema(object):
             schema_json = json.loads(schema_file.read())
             self.create_objects(schema_json["objects"])
             self.create_apis(schema_json["urls"])
+            # here loop over http methods for each url
+            keys = URL.URL_ENDPOINTS.keys()
+            for url in self.urls:
+                for key in keys:
+                    api = getattr(url, key, None)
+                    if api:  # and getattr(api, 'response', None):
+                        print "**** {} ****".format(url.url_path)
+                        print key
+                        if key == 'get':
+                            attrs = 'authorization', 'authorization_optional', 'content_type', \
+                                    'documentation', 'parameters_object', 'response_code', \
+                                    'response_object', 'url_path'
+                            if api.parameters_object:
+                                if api.parameters_object in self.data_objects:
+                                    print api.parameters_object
+                                else:
+                                    print "parameters_object doesn't exist"
+                            if api.response_code:
+                                print api.response_code
+                            if api.response_object:
+                                if api.response_object in self.data_objects:
+                                    print api.response_object
+                                else:
+                                    print "response_object doesn't exist"
+                        else:
+                            if api.request_object:
+                                if api.request_object in self.data_objects:
+                                    print api.request_object
+                                else:
+                                    print "request_object doesn't exist"
+                            if api.response_code:
+                                print api.response_code
+                            if api.response_object:
+                                if api.response_object in self.data_objects:
+                                    print api.response_object
+                                else:
+                                    print "response_object doesn't exist"
+                                    # raise SignalsError("Response Object does not exist")
 
     def create_apis(self, urls_json):
         for url_json in urls_json:

--- a/tests/files/invalid_endpoint_schema.json
+++ b/tests/files/invalid_endpoint_schema.json
@@ -54,9 +54,6 @@
     {"$validGetResponse": {
         "test_get": "string"
     }},
-    {"$invalidGetParameters": {
-        "test_get": "string"
-    }},
     {"$validPostRequest": {
         "message": "string"
     }},

--- a/tests/files/invalid_endpoint_schema.json
+++ b/tests/files/invalid_endpoint_schema.json
@@ -1,0 +1,21 @@
+{
+  "urls": [
+    {
+      "url": "invalid_post/",
+      "doc": "POST request with no response defined in schema",
+      "post": {
+        "#meta": "",
+        "doc": "Expects a base64 encoded password",
+        "request": "$invalidPostRequest",
+        "response": {
+          "200+": "$invalidPostResponse"
+        }
+      }
+    }
+  ],
+  "objects": [
+    {"$invalidPostRequest": {
+        "message": "Testing, testing..."
+    }}
+  ]
+}

--- a/tests/files/invalid_endpoint_schema.json
+++ b/tests/files/invalid_endpoint_schema.json
@@ -1,11 +1,45 @@
 {
   "urls": [
     {
+      "url": "valid_get/",
+      "doc": "GET request that is valid",
+      "get": {
+        "#meta": "",
+        "content_type": "form",
+        "parameters": "$validGetParameters",
+        "response": {
+          "200+": "$validGetResponse"
+        }
+      }
+    },
+    {
+      "url": "invalid_get/",
+      "doc": "GET request that is invalid",
+      "get": {
+        "#meta": "",
+        "content_type": "form",
+        "parameters": "$invalidGetParameters",
+        "response": {
+          "200+": "$invalidGetResponse"
+        }
+      }
+    },
+    {
+      "url": "valid_post/",
+      "doc": "POST request that is valid",
+      "post": {
+        "#meta": "",
+        "request": "$validPostRequest",
+        "response": {
+          "200+": "$validPostResponse"
+        }
+      }
+    },
+    {
       "url": "invalid_post/",
       "doc": "POST request with no response defined in schema",
       "post": {
         "#meta": "",
-        "doc": "Expects a base64 encoded password",
         "request": "$invalidPostRequest",
         "response": {
           "200+": "$invalidPostResponse"
@@ -14,8 +48,24 @@
     }
   ],
   "objects": [
+    {"$validGetParameters": {
+        "test_get": "string"
+    }},
+    {"$validGetResponse": {
+        "test_get": "string"
+    }},
+    {"$invalidGetParameters": {
+        "test_get": "string"
+    }},
+    {"$validPostRequest": {
+        "message": "string"
+    }},
+    {"$validPostResponse": {
+        "message": "string",
+        "success": "boolean"
+    }},
     {"$invalidPostRequest": {
-        "message": "Testing, testing..."
+        "message": "string"
     }}
   ]
 }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -78,6 +78,7 @@ class MainTestCase(unittest.TestCase):
     def test_validate_schema_path_fails(self, mock_path):
         bad_file_path = 'bad_path'
         mock_path.isfile.return_value = False
+        mock_path.exists.return_value = False
 
         args = {'ctx': None, 'param': None, 'value': bad_file_path}
         self.assertRaises(click.BadParameter, validate_path, **args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ import click
 import mock
 import unittest
 import subprocess
-from signals.main import run_main, add_trailing_slash_to_api, validate_schema_path
+from signals.main import run_main, add_trailing_slash_to_api, validate_path
 from signals.generators.base.base_generator import BaseGenerator
 from tests.utils import captured_stderr, captured_stdout
 
@@ -50,7 +50,7 @@ class MainTestCase(unittest.TestCase):
         full_path = '/projects/test.json'
         mock_path.isfile.return_value = True
 
-        validate_schema_path(None, None, full_path)
+        validate_path(None, None, full_path)
 
         mock_path.isfile.assert_called_with(full_path)
 
@@ -59,7 +59,7 @@ class MainTestCase(unittest.TestCase):
         no_home_dir_path = '~/test.json'
         mock_path.expanduser.return_value = '/projects/test.json'
 
-        validate_schema_path(None, None, no_home_dir_path)
+        validate_path(None, None, no_home_dir_path)
 
         mock_path.expanduser.assert_called_with(no_home_dir_path)
         mock_path.isfile.assert_called_with(mock_path.expanduser.return_value)
@@ -69,7 +69,7 @@ class MainTestCase(unittest.TestCase):
         no_home_dir_path = './test.json'
         mock_path.abspath.return_value = '/projects/test.json'
 
-        validate_schema_path(None, None, no_home_dir_path)
+        validate_path(None, None, no_home_dir_path)
 
         mock_path.abspath.assert_called_with(no_home_dir_path)
         mock_path.isfile.assert_called_with(mock_path.abspath.return_value)
@@ -80,7 +80,7 @@ class MainTestCase(unittest.TestCase):
         mock_path.isfile.return_value = False
 
         args = {'ctx': None, 'param': None, 'value': bad_file_path}
-        self.assertRaises(click.BadParameter, validate_schema_path, **args)
+        self.assertRaises(click.BadParameter, validate_path, **args)
 
     def test_add_trailing_slash_to_api(self):
         url_no_slash = 'http://test.com'


### PR DESCRIPTION
@rmutter @baylee 
https://github.com/yeti/signals/issues/38

- Added path validation to the `--datamodels` flag in `main.py`
- Added `validate_apis_and_objects` function to `schema.py`
  - Loop over the endpoints for each `url` in the schema, then search the `objects` dict for matches of `parameters`, `requests`, and `responses`, and throw an `error` if a match isn't found.