### PR TITLE
Remove app model from data model

### DIFF
--- a/signals/generators/ios/ios_generator.py
+++ b/signals/generators/ios/ios_generator.py
@@ -15,13 +15,12 @@ from signals.generators.ios import template_methods
 
 
 class iOSGenerator(BaseGenerator):
-    def __init__(self, schema, data_models_path, core_data_path, project_name, api_url):
+    def __init__(self, schema, data_models_path, core_data_path, project_name):
         super(iOSGenerator, self).__init__(schema)
         # Command flags
         self.data_models_path = data_models_path
         self.core_data_path = core_data_path
         self.project_name = project_name
-        self.api_url = api_url
 
         # Setup
         if not os.path.exists(BaseGenerator.BUILD_DIR):
@@ -52,7 +51,6 @@ class iOSGenerator(BaseGenerator):
     def create_implementation_file(self):
         self.process_template('data_model.m.j2', self.implementation_file, {
             'project_name': self.project_name,
-            'api_url': self.api_url,
             'VIDEO_FIELD': Field.VIDEO,
             'IMAGE_FIELD': Field.IMAGE,
             'request_objects': self.get_request_objects(self.schema.data_objects),

--- a/signals/generators/ios/templates/api_method.j2
+++ b/signals/generators/ios/templates/api_method.j2
@@ -2,7 +2,7 @@
   RKObjectManager* sharedMgr = [RKObjectManager sharedManager];
   sharedMgr.requestSerializationMIMEType = {{ content_type(api) }};
   {% if is_oauth(api) %}
-  [sharedMgr.HTTPClient setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Bearer %@", [AppModel sharedModel].accessToken]];
+  [sharedMgr.HTTPClient setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Bearer %@", [_delegate getAccessToken]]];
   {% endif %}
   {% if api.parameters_object %}
   {% include 'methods/parameters.j2' %}

--- a/signals/generators/ios/templates/data_model.h.j2
+++ b/signals/generators/ios/templates/data_model.h.j2
@@ -9,9 +9,18 @@
 @class RKMappingResult;
 @class UIImage;
 
+@protocol DataModelDelegate <NSObject>
+
+- (NSString*)getBaseURLString;
+- (NSString*)getAccessToken;
+
+@end
+
+
 @interface DataModel : NSObject
 
 + (DataModel *)sharedDataModel;
+@property (weak) id <DataModelDelegate> delegate;
 
 {% for url in schema.urls %}
 /**

--- a/signals/generators/ios/templates/data_model.m.j2
+++ b/signals/generators/ios/templates/data_model.m.j2
@@ -27,11 +27,8 @@
 
 - (void) setup {
   // Initialize RestKit
-  {% if is_url(api_url) %}
-  NSURL *baseURL = [NSURL URLWithString:@"{{ api_url }}"];
-  {% else %}
-  NSURL *baseURL = {{ api_url }};
-  {% endif %}
+  NSAssert(_delegate != NULL, @"Set DataModel.sharedDataModel().delegate before calling DataModel.sharedDataModel().setup()");
+  NSURL *baseURL = [NSURL URLWithString:[_delegate getBaseURLString]];
   RKObjectManager *objectManager = [RKObjectManager managerWithBaseURL:baseURL];
 
   // Enable Activity Indicator Spinner

--- a/signals/main.py
+++ b/signals/main.py
@@ -11,16 +11,15 @@ generators = {
 
 # Create a separate function so that we can unit test.
 # Issues unit testing `main` due to click decorators.
-def run_main(schema, generator_name, data_models, core_data, project_name, api_url, save):
+def run_main(schema, generator_name, data_models, core_data, project_name, save):
 
     schema = Schema(schema)
 
-    generator = generators[generator_name](schema, data_models, core_data, project_name, api_url)
+    generator = generators[generator_name](schema, data_models, core_data, project_name)
     try:
         generator.process()
         if save:
-            save_settings([data_models, core_data], schema, generator_name, data_models, core_data, project_name,
-                          api_url)
+            save_settings([data_models, core_data], schema, generator_name, data_models, core_data, project_name)
     except SignalsError as e:
         print(str(e))
     else:
@@ -46,7 +45,6 @@ def project_specified(ctx, param, value):
                  setting_dict["data_models"],
                  setting_dict["core_data"],
                  setting_dict["project_name"],
-                 setting_dict["api_url"],
                  False)
 
     if ctx is not None:
@@ -101,14 +99,8 @@ def validate_path(ctx, param, value):
               prompt="name of your iOS project and main target",
               help='The name of your iOS project and main target.',
               type=click.STRING)
-@click.option('api_url', '--apiurl',
-              prompt='the string url of your api or a method call that returns it',
-              help='The fully qualified url of your API for making calls or a method that will return the API, '
-                   'ex. Constants.getAPIURL()',
-              type=click.STRING,
-              callback=add_trailing_slash_to_api)
 @click.option('--save', is_flag=True)
 # TODO: These are iOS specific settings and we'll need to figure out a way to handle generator specific arguments
 # when we add more generators in the future.
-def main(settings_path, schema, generator, data_models, core_data, project_name, api_url, save):
-    run_main(schema, generator, data_models, core_data, project_name, api_url, save)
+def main(settings_path, schema, generator, data_models, core_data, project_name, save):
+    run_main(schema, generator, data_models, core_data, project_name, save)

--- a/signals/settings.py
+++ b/signals/settings.py
@@ -22,7 +22,7 @@ def load_settings(settings_path):
     return setting_dict
 
 
-def save_settings(paths, schema, generator_name, data_models, core_data, project_name, api_url):
+def save_settings(paths, schema, generator_name, data_models, core_data, project_name):
     project_root = find_project_root(paths)
     if project_root is not None and len(project_root) > 0:
         output_settings(project_root,
@@ -30,8 +30,7 @@ def save_settings(paths, schema, generator_name, data_models, core_data, project
                         generator_name,
                         os.path.abspath(data_models),
                         os.path.abspath(core_data) if core_data else "",
-                        project_name,
-                        api_url)
+                        project_name)
     else:
         raise SignalsError("Failed to locate project root")
 
@@ -50,11 +49,11 @@ def find_project_root(paths):
     return None
 
 
-def output_settings(project_root, schema, generator_name, data_models, core_data, project_name, api_url):
+def output_settings(project_root, schema, generator_name, data_models, core_data, project_name):
     settings_filename = project_root + os.sep + ".signalsconfig"
     progress("Writing settings to {}".format(settings_filename))
-    keys = ["schema", "generator", "data_models", "core_data", "project_name", "api_url"]
-    values = [schema, generator_name, data_models, core_data, project_name, api_url]
+    keys = ["schema", "generator", "data_models", "core_data", "project_name"]
+    values = [schema, generator_name, data_models, core_data, project_name]
 
     with open(settings_filename, "w") as settings_file:
         for (key, val) in zip(keys, values):

--- a/tests/generators/ios/files/APIMethod.m
+++ b/tests/generators/ios/files/APIMethod.m
@@ -1,6 +1,6 @@
 - (void) getPostWithSuccess:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure {
   RKObjectManager* sharedMgr = [RKObjectManager sharedManager];
   sharedMgr.requestSerializationMIMEType = RKMIMETypeJSON;
-  [sharedMgr.HTTPClient setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Bearer %@", [AppModel sharedModel].accessToken]];
+  [sharedMgr.HTTPClient setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Bearer %@", [_delegate getAccessToken]]];
   [sharedMgr getObject:nil path:@"post/" parameters:nil success:success failure:failure];
 }

--- a/tests/generators/ios/files/DataModel.h
+++ b/tests/generators/ios/files/DataModel.h
@@ -9,9 +9,18 @@
 @class RKMappingResult;
 @class UIImage;
 
+@protocol DataModelDelegate <NSObject>
+
+- (NSString*)getBaseURLString;
+- (NSString*)getAccessToken;
+
+@end
+
+
 @interface DataModel : NSObject
 
 + (DataModel *)sharedDataModel;
+@property (weak) id <DataModelDelegate> delegate;
 
 /**
 

--- a/tests/generators/ios/files/DataModel.m
+++ b/tests/generators/ios/files/DataModel.m
@@ -25,7 +25,8 @@
 
 - (void) setup {
   // Initialize RestKit
-  NSURL *baseURL = [NSURL URLWithString:@"http://test.com/api/v1/"];
+  NSAssert(_delegate != NULL, @"Set DataModel.sharedDataModel().delegate before calling DataModel.sharedDataModel().setup()");
+  NSURL *baseURL = [NSURL URLWithString:[_delegate getBaseURLString]];
   RKObjectManager *objectManager = [RKObjectManager managerWithBaseURL:baseURL];
 
   // Enable Activity Indicator Spinner

--- a/tests/generators/ios/test_ios_generator.py
+++ b/tests/generators/ios/test_ios_generator.py
@@ -25,7 +25,7 @@ class iOSGeneratorTestCase(unittest.TestCase):
     def test_process_error(self, mock_subprocess):
         mock_subprocess.check_output.return_value = "Xcode.app"
         generator = iOSGenerator(Schema("./tests/files/test_schema.json"), "./tests/files/", "./core/data/path",
-                                 "YetiProject", "http://test.com/api/v1/")
+                                 "YetiProject")
         with self.assertRaises(SignalsError) as e:
             generator.process()
         self.assertEqual(e.exception.msg, "Must quit Xcode before writing to core data")
@@ -33,13 +33,13 @@ class iOSGeneratorTestCase(unittest.TestCase):
     @mock.patch("signals.generators.ios.ios_generator.recursively_find_parent_containing_file", side_effect=good_app_delegate)
     def test_check_setup_called_success(self, mock_function):
         generator = iOSGenerator(Schema("./tests/files/test_schema.json"), "./tests/files/", "./core/data/path",
-                                 "YetiProject", "http://test.com/api/v1/")
+                                 "YetiProject")
         self.assertTrue(generator.check_setup_called())
 
     @mock.patch("signals.generators.ios.ios_generator.recursively_find_parent_containing_file", side_effect=bad_app_delegate)
     def test_check_setup_called_failure(self, mock_function):
         generator = iOSGenerator(Schema("./tests/files/test_schema.json"), "./tests/files/", "./core/data/path",
-                                 "YetiProject", "http://test.com/api/v1/")
+                                 "YetiProject")
         self.assertFalse(generator.check_setup_called())
 
 

--- a/tests/generators/ios/test_templates.py
+++ b/tests/generators/ios/test_templates.py
@@ -211,7 +211,6 @@ class TemplateTestCase(unittest.TestCase):
         schema = Schema("./tests/files/test_schema.json")
         self.assertTemplateEqual('data_model.m.j2', 'DataModel.m', {
             'project_name': "TestProject",
-            'api_url': "http://test.com/api/v1/",
             'schema': schema,
             'VIDEO_FIELD': Field.VIDEO,
             'IMAGE_FIELD': Field.IMAGE,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,7 @@ from tests.utils import captured_stderr, captured_stdout
 class MainTestCase(unittest.TestCase):
     def test_run_command(self):
         command = "python -m signals --schema ./tests/files/test_schema.json --generator ios " \
-                  "--datamodels ./tests/files/ --projectname YetiProject --apiurl http://test.com/api/v1/"
+                  "--datamodels ./tests/files/ --projectname YetiProject"
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output, error = process.communicate()
         self.assertEqual(error, "")
@@ -19,8 +19,7 @@ class MainTestCase(unittest.TestCase):
 
     def test_run_main(self):
         with captured_stderr() as error, captured_stdout() as out:
-            run_main("./tests/files/test_schema.json", "ios", "./tests/files/", None, "YetiProject",
-                     "http://test.com/api/v1/", False)
+            run_main("./tests/files/test_schema.json", "ios", "./tests/files/", None, "YetiProject", False)
             self.assertEqual(error.getvalue(), "")
             self.assertIn("Finished generating your files!", out.getvalue())
 
@@ -29,7 +28,7 @@ class MainTestCase(unittest.TestCase):
         mock_subprocess.check_output.return_value = "Xcode.app"
         with captured_stdout() as out:
             run_main("./tests/files/test_schema.json", "ios", "./tests/files/", "./core/data/path", "YetiProject",
-                     "http://test.com/api/v1/", False)
+                     False)
             self.assertIn("Must quit Xcode before writing to core data", out.getvalue())
 
     def test_clear_generated_code_files(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,7 +14,7 @@ class SettingsTestCase(unittest.TestCase):
         # Run normally to generate settings file
         with captured_stderr() as error, captured_stdout() as out:
             run_main("./tests/files/test_schema.json", "ios", "./tests/files/", "./tests/files/dummycontents",
-                     "YetiProject", "http://test.com", True)
+                     "YetiProject", True)
             self.assertEqual(error.getvalue(), "")
             self.assertIn("Finished generating your files!", out.getvalue())
 


### PR DESCRIPTION
DataModel now has a delegate which must be set before calling setup.  The delegate is used by DataModel to retrieve the URL of the API, and also to retrieve the auth token.  This also simplifies our CLI slightly, as the api_url argument is no longer needed.
fixes #27 
@rmutter @walkingtowork @baylee 