### PR TITLE
Associate data objects with model instances. Improve schema

### DIFF
--- a/signals/generators/ios/template_methods.py
+++ b/signals/generators/ios/template_methods.py
@@ -10,7 +10,7 @@ from signals.parser.api import API, GetAPI
 from signals.parser.fields import Field
 
 
-def method_name(api, data_objects):
+def method_name(api):
     # First create camel cased name from snake case
     method_name_string = ""
     for part in re.split(r'[/_]+', api.url_path):
@@ -20,7 +20,7 @@ def method_name(api, data_objects):
             method_name_string += part.capitalize()
 
     first_parameter_name = "Success"
-    request_object = get_api_request_object(api, data_objects)
+    request_object = get_api_request_object(api)
     if request_object and len(request_object.properties()) > 0:
         first_field = request_object.properties()[0]
         first_parameter_name = get_proper_name(first_field.name, capitalize_first=True)
@@ -30,11 +30,11 @@ def method_name(api, data_objects):
     return "{}With{}".format(method_name_string, first_parameter_name)
 
 
-def method_parameters(api, data_objects):
+def method_parameters(api):
     parameters = []
 
     # Create request object parameters
-    request_object = get_api_request_object(api, data_objects)
+    request_object = get_api_request_object(api)
     if request_object:
         parameters.extend(generate_field_parameters(request_object))
         parameters.extend(generate_relationship_parameters(request_object))
@@ -66,10 +66,10 @@ def key_path(api):
 
 
 def get_object_name(request_object, upper_camel_case=False):
-    first_letter = request_object[1]
+    first_letter = request_object.name[1]
     if upper_camel_case:
         first_letter = first_letter.upper()
-    return first_letter + request_object[2:]
+    return first_letter + request_object.name[2:]
 
 
 def get_url_name(url_path):
@@ -135,8 +135,6 @@ def create_parameter_signature(parameters):
     return " ".join(method_parts)
 
 
-def get_api_request_object(api, data_objects):
+def get_api_request_object(api):
     # We treat both request and parameter objects equally in method signatures
-    request_object_name = getattr(api, 'request_object', getattr(api, 'parameters_object', None))
-    if request_object_name:
-        return data_objects[request_object_name]
+    return getattr(api, 'request_object', getattr(api, 'parameters_object', None))

--- a/signals/generators/ios/templates/api_method.j2
+++ b/signals/generators/ios/templates/api_method.j2
@@ -1,4 +1,4 @@
-- (void) {{ api.method }}{{ method_name(api, schema.data_objects) }}:{{ method_parameters(api, schema.data_objects) }} {
+- (void) {{ api.method }}{{ method_name(api) }}:{{ method_parameters(api) }} {
   RKObjectManager* sharedMgr = [RKObjectManager sharedManager];
   sharedMgr.requestSerializationMIMEType = {{ content_type(api) }};
   {% if is_oauth(api) %}

--- a/signals/generators/ios/templates/data_model.h.j2
+++ b/signals/generators/ios/templates/data_model.h.j2
@@ -26,7 +26,7 @@
 {% for endpoint in endpoints %}
   {% if url[endpoint] %}
     {% with api = url[endpoint] %}
-- (void) {{ api.method }}{{ method_name(api, schema.data_objects) }}:{{ method_parameters(api, schema.data_objects) }};
+- (void) {{ api.method }}{{ method_name(api) }}:{{ method_parameters(api) }};
 
     {% endwith %}
   {% endif %}

--- a/signals/generators/ios/templates/data_model.m.j2
+++ b/signals/generators/ios/templates/data_model.m.j2
@@ -10,7 +10,7 @@
 
 // Request object imports
 {% for request_object in request_objects %}
-#import "{{ get_object_name(request_object.name, upper_camel_case=True) }}.h"
+#import "{{ get_object_name(request_object, upper_camel_case=True) }}.h"
 {% endfor %}
 
 @implementation DataModel
@@ -53,7 +53,7 @@
 
   // MARK: RestKit Entity Relationship Mappings
   // We place the relationship mappings after the entities so that we don't need to worry about ordering
-  {% for name, data_object in schema.data_objects.iteritems() %}
+  {% for data_object in schema.data_objects.itervalues() %}
     {% for relationship in data_object.relationships %}
       {% include 'relationship_mapping.j2' %}
 

--- a/signals/generators/ios/templates/entity_mapping.j2
+++ b/signals/generators/ios/templates/entity_mapping.j2
@@ -1,5 +1,5 @@
-  {% set mapping_name = get_object_name(data_object.name) %}
-  RKEntityMapping *{{ mapping_name }}Mapping = [RKEntityMapping mappingForEntityForName:@"{{ get_object_name(data_object.name, upper_camel_case=True) }}" inManagedObjectStore:managedObjectStore];
+  {% set mapping_name = get_object_name(data_object) %}
+  RKEntityMapping *{{ mapping_name }}Mapping = [RKEntityMapping mappingForEntityForName:@"{{ get_object_name(data_object, upper_camel_case=True) }}" inManagedObjectStore:managedObjectStore];
   {% if data_object.fields|length > 0 %}
   {% for field in data_object.fields %}
     {% if field.primary_key %}

--- a/signals/generators/ios/templates/methods/parameters.j2
+++ b/signals/generators/ios/templates/methods/parameters.j2
@@ -1,4 +1,4 @@
-  {% set parameters_object = schema.data_objects[api.parameters_object] %}
+  {% set parameters_object = api.parameters_object %}
   NSMutableDictionary* queryParams = [NSMutableDictionary dictionaryWithCapacity:{{ parameters_object.fields|length }}];
   {% for field in parameters_object.fields %}
   if ({{ get_proper_name(field.name) }}) {

--- a/signals/generators/ios/templates/methods/request.j2
+++ b/signals/generators/ios/templates/methods/request.j2
@@ -1,5 +1,5 @@
   {% set request_object_name = get_object_name(api.request_object, upper_camel_case=True) %}
-  {% set request_object = schema.data_objects[api.request_object] %}
+  {% set request_object = api.request_object %}
   {{ request_object_name }} *obj = [NSEntityDescription insertNewObjectForEntityForName:@"{{ request_object_name }}" inManagedObjectContext:sharedMgr.managedObjectStore.mainQueueManagedObjectContext];
   {% for field in request_object.properties() %}
     {% if field.field_type not in [VIDEO_FIELD, IMAGE_FIELD] %}

--- a/signals/generators/ios/templates/relationship_mapping.j2
+++ b/signals/generators/ios/templates/relationship_mapping.j2
@@ -1,3 +1,3 @@
-  {% set from_mapping_name = get_object_name(name) %}
+  {% set from_mapping_name = get_object_name(data_object) %}
   {% set to_mapping_name = get_object_name(relationship.related_object) %}
   [{{ from_mapping_name }}Mapping addPropertyMapping:[RKRelationshipMapping relationshipMappingFromKeyPath:@"{{ relationship.name }}" toKeyPath:@"{{ relationship.name }}" withMapping:{{ to_mapping_name }}Mapping]];

--- a/tests/files/empty_schema.json
+++ b/tests/files/empty_schema.json
@@ -1,4 +1,4 @@
 {
   "urls": [],
-  "objects": []
+  "objects": {}
 }

--- a/tests/files/test_schema.json
+++ b/tests/files/test_schema.json
@@ -23,23 +23,23 @@
       }
     }
   ],
-  "objects": [
-    {"$signUpRequest": {
-        "fullname": "string",
-        "username": "string",
-        "email": "string,optional",
-        "password": "string"
-    }},
-    {"$signUpResponse": {
-        "fullname": "string",
-        "username": "string",
-        "email": "string,optional",
-        "client_id": "string",
-        "client_secret": "string"
-    }},
-    {"$loginResponse": {
-        "client_id": "string",
-        "client_secret": "string"
-    }}
-  ]
+  "objects": {
+    "$signUpRequest": {
+      "fullname": "string",
+      "username": "string",
+      "email": "string,optional",
+      "password": "string"
+    },
+    "$signUpResponse": {
+      "fullname": "string",
+      "username": "string",
+      "email": "string,optional",
+      "client_id": "string",
+      "client_secret": "string"
+    },
+    "$loginResponse": {
+      "client_id": "string",
+      "client_secret": "string"
+    }
+  }
 }

--- a/tests/generators/ios/test_parameters.py
+++ b/tests/generators/ios/test_parameters.py
@@ -2,6 +2,7 @@ import unittest
 from signals.generators.ios.parameters import has_id_field, create_id_parameter, generate_relationship_parameters, \
     generate_field_parameters
 from signals.parser.schema import DataObject
+from tests.utils import create_dynamic_schema
 
 
 class ParametersTestCase(unittest.TestCase):
@@ -31,11 +32,16 @@ class ParametersTestCase(unittest.TestCase):
         self.assertIsNone(create_id_parameter("/post/:id/", request_object))
 
     def test_generate_relationship_parameters(self):
-        request_object = DataObject("$userRequest", {
-            "username": "string",
-            "profile": "O2O,$profileRequest",
-            "tags": "M2M,$tagRequest"
-        })
+        schema = create_dynamic_schema({
+            "$userRequest": {
+                "username": "string",
+                "profile": "O2O,$profileRequest",
+                "tags": "M2M,$tagRequest"
+            },
+            "$profileRequest": {},
+            "$tagRequest": {}
+        }, [])
+        request_object = schema.data_objects['$userRequest']
         parameters = generate_relationship_parameters(request_object)
         self.assertEqual(parameters[0].name, "profile")
         self.assertEqual(parameters[0].objc_type, "ProfileRequest")

--- a/tests/parser/test_schema.py
+++ b/tests/parser/test_schema.py
@@ -40,14 +40,14 @@ class SchemaTestCase(unittest.TestCase):
     def test_create_objects(self):
         schema = Schema("./tests/files/empty_schema.json")
         self.assertEqual(schema.data_objects, {})
-        schema.create_objects([
-            {"$resetPasswordRequest": {
+        schema.create_objects({
+            "$resetPasswordRequest": {
                 "email": "string"
-            }},
-            {"$resetPasswordResponse": {
+            },
+            "$resetPasswordResponse": {
                 "status": "string"
-            }}
-        ])
+            }
+        })
         self.assertEqual(len(schema.data_objects), 2)
         self.assertEqual(schema.data_objects['$resetPasswordRequest'].name, '$resetPasswordRequest')
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import sys
 import contextlib
 from StringIO import StringIO
+from signals.parser.schema import Schema
 
 
 @contextlib.contextmanager
@@ -30,3 +31,11 @@ def captured_stderr():
 
 def captured_stdin():
     return captured_output("stdin")
+
+def create_dynamic_schema(objects_json, urls_json):
+    schema = Schema("./tests/files/empty_schema.json")
+    schema.create_objects(objects_json)
+    schema.create_apis(urls_json)
+    schema.validate_apis_and_objects()
+    schema.add_relationship_objects()
+    return schema


### PR DESCRIPTION
Fixes #23 
@rmutter for review

- Before we were storing object names on the `API` and `Relationship` classes -- we are now storing a reference to the actual object. This meant a lot of test updates.
- Removes unnecessary dictionary wraps in the schema file. I left off any other improvements to the schema until we decide on a more universal standard as discussed in #15. Ideally it would be cool if we could have different parsers for different styles, e.g. Swagger parser, RAML parser, etc.