### PR TITLE
Remove -Swift import in DataModel.m

### DIFF
--- a/signals/generators/ios/templates/objc/data_model.m.j2
+++ b/signals/generators/ios/templates/objc/data_model.m.j2
@@ -6,7 +6,6 @@
 #import "DataModel.h"
 #import <CoreData/CoreData.h>
 #import <RestKit/RestKit.h>
-#import "{{ project_name }}-Swift.h"
 
 // Request object imports
 {% for request_object in request_objects %}

--- a/tests/generators/ios/objc/files/DataModel.m
+++ b/tests/generators/ios/objc/files/DataModel.m
@@ -6,7 +6,6 @@
 #import "DataModel.h"
 #import <CoreData/CoreData.h>
 #import <RestKit/RestKit.h>
-#import "TestProject-Swift.h"
 
 // Request object imports
 #import "SignUpRequest.h"


### PR DESCRIPTION
@rmutter Removed this line from the Jinja template that causes problems when you're running an Objective-C project with Objective-C generated signals code. They will have to add this line (along with adding a bridging header, etc.) if they decide to mix languages, but I feel like that isn't the path we should support by default.