### PR TITLE
Update swift templates to Swift2

### DIFF
--- a/signals/generators/ios/templates/objc/data_model.h.j2
+++ b/signals/generators/ios/templates/objc/data_model.h.j2
@@ -42,8 +42,6 @@
 {% endfor %}
 {% endfor %}
 
-- (void) getAllLoginWithUsername:(NSString*)username password:(NSString*)password success:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure;
-
 - (void) setup:(id<DataModelDelegate>)delegate;
 
 @end

--- a/signals/generators/ios/templates/objc/data_model.m.j2
+++ b/signals/generators/ios/templates/objc/data_model.m.j2
@@ -112,11 +112,5 @@
   {% endif %}
 {% endfor %}
 {% endfor %}
-- (void) getAllLoginWithUsername:(NSString*)username password:(NSString*)password success:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure {
-  RKObjectManager* sharedMgr = [RKObjectManager sharedManager];
-  [sharedMgr.HTTPClient setAuthorizationHeaderWithUsername:username password:password];
-  sharedMgr.requestSerializationMIMEType = RKMIMETypeFormURLEncoded;
-  [sharedMgr getObjectsAtPath:@"login/" parameters:nil success:success failure:failure];
-}
 
 @end

--- a/signals/generators/ios/templates/swift/api_method.j2
+++ b/signals/generators/ios/templates/swift/api_method.j2
@@ -1,14 +1,14 @@
-func {{ api.method }}{{ method_name(api) }}({{ method_parameters(api) }}) {
-  var sharedMgr = RKObjectManager.sharedManager()
-  sharedMgr.requestSerializationMIMEType = {{ content_type(api) }}
-  {% if is_oauth(api) %}
-  sharedMgr.HTTPClient.setDefaultHeader("Authorization", value: NSString.stringWithFormat("Bearer \(_delegate.getAccessToken())"))
-  {% endif %}
-  {% if api.parameters_object %}
-  {% include 'methods/parameters.j2' %}
-  {% elif api.request_object %}
-  {% include 'methods/request.j2' %}
-  {% else %}
-  {% include 'methods/send_object.j2' %}
-  {% endif %}
-}
+  func {{ api.method }}{{ method_name(api) }}({{ method_parameters(api) }}) {
+    let sharedMgr = RKObjectManager.sharedManager()
+    sharedMgr.requestSerializationMIMEType = {{ content_type(api) }}
+    {% if is_oauth(api) %}
+    sharedMgr.HTTPClient.setDefaultHeader("Authorization", value: NSString.stringWithFormat("Bearer \(_delegate.getAccessToken())"))
+    {% endif %}
+    {% if api.parameters_object %}
+    {% include 'methods/parameters.j2' %}
+    {% elif api.request_object %}
+    {% include 'methods/request.j2' %}
+    {% else %}
+    {% include 'methods/send_object.j2' %}
+    {% endif %}
+  }

--- a/signals/generators/ios/templates/swift/data_model.swift.j2
+++ b/signals/generators/ios/templates/swift/data_model.swift.j2
@@ -10,115 +10,111 @@ import RestKit
 typealias RestKitSuccess = (operation: RKObjectRequestOperation!, result: RKMappingResult!) -> Void
 typealias RestKitError = (operation: RKObjectRequestOperation!, error: NSError!) -> Void
 
-@objc public class DataModel: NSObject {
-  var getBaseURLString: String?
-  var getAccessToken: String?
+protocol DataModelDelegate {
+  func getBaseURLString() -> String
+  func getAccessToken() -> String
+}
 
-  class var sharedDataModel: DataModel {
+class DataModel: NSObject {
+  var delegate: DataModelDelegate?
+
+  class func sharedDataModel() -> DataModel {
     struct Static {
-      static var __sharedDataModel = nil
+      static var __sharedDataModel: DataModel? = nil
       static var onceToken: dispatch_once_t = 0
     }
 
     dispatch_once(&Static.onceToken) {
-      __sharedDataModel = DataModel.alloc().init()
+      Static.__sharedDataModel = DataModel.init()
     }
 
     return Static.__sharedDataModel!
   }
-}
 
-func setup(delegate: DataModelDelegate) {
-  // Initialize RestKit
-  _delegate = delegate;
-  assert(_delegate != nil, "delegate parameter cannot be nil")
-  var baseURL = NSURL.URLWithString(_delegate.getBaseURLString())
-  var objectManager = RKObjectManager.managerWithBaseURL(baseURL)
+  func setup(delegate: DataModelDelegate) {
+    // Initialize RestKit
+    let _delegate = delegate;
+    let baseURL = NSURL(string: _delegate.getBaseURLString())
+    let objectManager = RKObjectManager(baseURL: baseURL)
 
-  // Enable Activity Indicator Spinner
-  AFNetworkActivityIndicatorManager.sharedManager().enabled = true;
+    // Enable Activity Indicator Spinner
+    AFNetworkActivityIndicatorManager.sharedManager().enabled = true;
 
-  // Initialize managed object store
-  var managedObjectModel = NSManagedObjectModel.mergedModelFromBundles(nil)
-  var managedObjectStore = RKManagedObjectStore.alloc().initWithManagedObjectModel(managedObjectModel)
+    // Initialize managed object store
+    let managedObjectModel = NSManagedObjectModel.mergedModelFromBundles(nil)
+    let managedObjectStore = RKManagedObjectStore(managedObjectModel: managedObjectModel)
 
-  objectManager.managedObjectStore = managedObjectStore;
+    objectManager.managedObjectStore = managedObjectStore;
 
-  // MARK: RestKit Entity Mappings
-  {% for name, data_object in schema.data_objects.iteritems() %}
-    {% if 'Parameters' not in name %}
-      {% include 'entity_mapping.j2' %}
+    // MARK: RestKit Entity Mappings
+    {% for name, data_object in schema.data_objects.iteritems() %}
+      {% if 'Parameters' not in name %}
+        {% include 'entity_mapping.j2' %}
 
-    {% endif %}
-  {% endfor %}
-
-  // MARK: RestKit Entity Relationship Mappings
-  // We place the relationship mappings after the entities so that we don't need to worry about ordering
-  {% for data_object in schema.data_objects.itervalues() %}
-    {% for relationship in data_object.relationships %}
-      {% include 'relationship_mapping.j2' %}
-
+      {% endif %}
     {% endfor %}
-  {% endfor %}
 
-  // MARK: RestKit URL Descriptors
-  {% for url in schema.urls %}
+    // MARK: RestKit Entity Relationship Mappings
+    // We place the relationship mappings after the entities so that we don't need to worry about ordering
+    {% for data_object in schema.data_objects.itervalues() %}
+      {% for relationship in data_object.relationships %}
+        {% include 'relationship_mapping.j2' %}
+
+      {% endfor %}
+    {% endfor %}
+
+    // MARK: RestKit URL Descriptors
+    {% for url in schema.urls %}
+    {% for endpoint in endpoints %}
+      {% if url[endpoint] %}
+        {% with api = url[endpoint] %}
+          {% if endpoint in ['patch', 'post'] %}
+            {% include 'descriptors/request.j2' %}
+
+
+          {% endif %}
+          {% if endpoint in ['get', 'patch', 'post'] %}
+            {% include 'descriptors/response.j2' %}
+
+
+          {% endif %}
+        {% endwith %}
+      {% endif %}
+    {% endfor %}
+    {% endfor %}
+
+    /**
+    Complete Core Data stack initialization
+    */
+    managedObjectStore.createPersistentStoreCoordinator()
+    let storePath = (RKApplicationDataDirectory() as NSString).stringByAppendingPathComponent("{{ project_name }}.sqlite")
+
+    do {
+      try managedObjectStore.addSQLitePersistentStoreAtPath(storePath, fromSeedDatabaseAtPath: nil, withConfiguration: nil, options: nil)
+    } catch {
+      // Problem creating persistent store, wipe it since there was probably a core data change
+      // Causes runtime crash if still unable to create persistant storage
+      try! NSFileManager.defaultManager().removeItemAtPath(storePath)
+      try! managedObjectStore.addSQLitePersistentStoreAtPath(storePath, fromSeedDatabaseAtPath: nil, withConfiguration: nil, options: nil)
+    }
+
+    // Create the managed object contexts
+    managedObjectStore.createManagedObjectContexts()
+
+    // Configure a managed object cache to ensure we do not create duplicate objects
+    managedObjectStore.managedObjectCache = RKInMemoryManagedObjectCache(managedObjectContext: managedObjectStore.persistentStoreManagedObjectContext)
+  }
+
+  // MARK: API Calls
+  {% for url in schema.urls -%}
   {% for endpoint in endpoints %}
     {% if url[endpoint] %}
       {% with api = url[endpoint] %}
-        {% if endpoint in ['patch', 'post'] %}
-          {% include 'descriptors/request.j2' %}
+        {% include 'api_method.j2' %}
 
 
-        {% endif %}
-        {% if endpoint in ['get', 'patch', 'post'] %}
-          {% include 'descriptors/response.j2' %}
-
-
-        {% endif %}
       {% endwith %}
     {% endif %}
   {% endfor %}
   {% endfor %}
-
-  /**
-   Complete Core Data stack initialization
-   */
-  managedObjectStore.createPersistentStoreCoordinator()
-  var storePath = RKApplicationDataDirectory().stringByAppendingPathComponent("{{ project_name }}.sqlite")
-  var error: NSError
-  var persistentStore = managedObjectStore.addSQLitePersistentStoreAtPath(storePath, fromSeedDatabaseAtPath: nil, withConfiguration: nil, options: nil, error: &error)
-
-  // Problem creating persistent store, wipe it since there was probably a core data change
-  if (persistentStore == nil) {
-    NSFileManager.defaultManager().removeItemAtPath(storePath, error: nil)
-    persistentStore = managedObjectStore.addSQLitePersistentStoreAtPath(storePath, fromSeedDatabaseAtPath: nil, withConfiguration: nil, options: nil, error: &error)
-  }
-
-  assert(persistentStore, "Failed to add persistent store with error: \(error)")
-
-  // Create the managed object contexts
-  managedObjectStore.createManagedObjectContexts()
-
-  // Configure a managed object cache to ensure we do not create duplicate objects
-  managedObjectStore.managedObjectCache = RKInMemoryManagedObjectCache.alloc().initWithManagedObjectContext(managedObjectStore.persistentStoreManagedObjectContext)
-}
-
-// MARK: API Calls
-{% for url in schema.urls -%}
-{% for endpoint in endpoints %}
-  {% if url[endpoint] %}
-    {% with api = url[endpoint] %}
-      {% include 'api_method.j2' %}
-
-
-    {% endwith %}
-  {% endif %}
-{% endfor %}
-{% endfor %}
-func getAllLoginWithUsername(username: String, password: String, success: RestKitSuccess, failure: RestKitFailure) {
-  var sharedMgr = RKObjectManager.sharedManager()
-  sharedMgr.HTTPClient.setAuthorizationHeaderWithUsername(username, password: password)
-  sharedMgr.requestSerializationMIMEType = RKMIMETypeFormURLEncoded
-  sharedMgr.getObjectsAtPath("login/", parameters: nil, success: success, failure: failure)
 }

--- a/signals/generators/ios/templates/swift/descriptors/request.j2
+++ b/signals/generators/ios/templates/swift/descriptors/request.j2
@@ -1,8 +1,8 @@
 {% set mapping_name = get_object_name(api.request_object) %}
 {% set descriptor_name = get_url_name(api.url_path) + api.method|capitalize %}
-{% if api.method == 'patch' %}
-  var {{ mapping_name }}MappingInverse = {{ mapping_name }}Mapping.inverseMapping()
-  {{ mapping_name }}MappingInverse.assignsDefaultValueForMissingAttributes = false
+  {% if api.method == 'patch' %}
+    let {{ mapping_name }}MappingInverse = {{ mapping_name }}Mapping.inverseMapping()
+    {{ mapping_name }}MappingInverse.assignsDefaultValueForMissingAttributes = false
 {% endif %}
-  var {{ descriptor_name }}RequestDescriptor = RKRequestDescriptor.requestDescriptorWithMapping({{ mapping_name }}Mapping.inverseMapping(), objectClass: {{ get_object_name(api.request_object, upper_camel_case=True) }}.self, rootKeyPath: nil, method: RKRequestMethod{{ api.method|upper }})
-  objectManager.addRequestDescriptor({{ descriptor_name }}RequestDescriptor)
+    let {{ descriptor_name }}RequestDescriptor = RKRequestDescriptor(mapping: {{ mapping_name }}Mapping.inverseMapping(), objectClass: {{ get_object_name(api.request_object, upper_camel_case=True) }}.self, rootKeyPath: nil, method: RKRequestMethod.{{ api.method|upper }})
+    objectManager.addRequestDescriptor({{ descriptor_name }}RequestDescriptor)

--- a/signals/generators/ios/templates/swift/descriptors/response.j2
+++ b/signals/generators/ios/templates/swift/descriptors/response.j2
@@ -1,4 +1,4 @@
 {% set url_name = get_url_name(api.url_path) %}
 {% set descriptor_name = url_name + api.method|capitalize %}
-  var {{ descriptor_name }}ResponseDescriptor = RKResponseDescriptor.responseDescriptorWithMapping({{ get_object_name(api.response_object) }}Mapping, method: RKRequestMethod{{ api.method|upper }}, pathPattern: "{{ api.url_path }}", keyPath: {{ key_path(api) }}, statusCodes: RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful))
-  objectManager.addResponseDescriptor({{ descriptor_name }}ResponseDescriptor)
+    let {{ descriptor_name }}ResponseDescriptor = RKResponseDescriptor(mapping: {{ get_object_name(api.response_object) }}Mapping, method: RKRequestMethod.{{ api.method|upper }}, pathPattern: "{{ api.url_path }}", keyPath: {{ key_path(api) }}, statusCodes: RKStatusCodeIndexSetForClass(RKStatusCodeClass.Successful))
+    objectManager.addResponseDescriptor({{ descriptor_name }}ResponseDescriptor)

--- a/signals/generators/ios/templates/swift/entity_mapping.j2
+++ b/signals/generators/ios/templates/swift/entity_mapping.j2
@@ -1,11 +1,11 @@
-  {% set mapping_name = get_object_name(data_object) %}
-  var {{ mapping_name }}Mapping = RKEntityMapping.mappingForEntityForName({{ get_object_name(data_object, upper_camel_case=True) }}, inManagedObjectStore: managedObjectStore)
-  {% if data_object.fields|length > 0 %}
-  {% for field in data_object.fields %}
-    {% if field.primary_key %}
-  {{ mapping_name }}Mapping.identificationAttributes = ["\({{ sanitize_field_name(field.name) }})"]
+    {% set mapping_name = get_object_name(data_object) %}
+    let {{ mapping_name }}Mapping = RKEntityMapping(forEntityForName: "{{ get_object_name(data_object, upper_camel_case=True) }}", inManagedObjectStore: managedObjectStore)
+    {% if data_object.fields|length > 0 %}
+    {% for field in data_object.fields %}
+      {% if field.primary_key %}
+    {{ mapping_name }}Mapping.identificationAttributes = ["\({{ sanitize_field_name(field.name) }})"]
+      {% endif %}
+    {% endfor %}
+    {{ mapping_name }}Mapping.addAttributeMappingsFromDictionary([ {{ attribute_mappings(data_object.fields) }} ])
     {% endif %}
-  {% endfor %}
-  {{ mapping_name }}Mapping.addAttributeMappingsFromDictionary([ {{ attribute_mappings(data_object.fields) }} ])
-  {% endif %}
 

--- a/signals/generators/ios/templates/swift/methods/parameters.j2
+++ b/signals/generators/ios/templates/swift/methods/parameters.j2
@@ -1,8 +1,8 @@
-  {% set parameters_object = api.parameters_object %}
-  var queryParams = NSMutableDictionary(capacity: {{ parameters_object.fields|length }})
-  {% for field in parameters_object.fields %}
-  if ({{ get_proper_name(field.name) }}) {
-    queryParams.setObject({{ get_proper_name(field.name) }}, forKey: "{{ field.name }}")
-  }
-  {% endfor %}
-  sharedMgr.getObjectsAtPath("{{ api.url_path }}", parameters: queryParams, success: success, failure: failure)
+    {% set parameters_object = api.parameters_object %}
+    let queryParams = NSMutableDictionary(capacity: {{ parameters_object.fields|length }})
+    {% for field in parameters_object.fields %}
+    if ({{ get_proper_name(field.name) }}) {
+      queryParams.setObject({{ get_proper_name(field.name) }}, forKey: "{{ field.name }}")
+    }
+    {% endfor %}
+    sharedMgr.getObjectsAtPath("{{ api.url_path }}", parameters: queryParams, success: success, failure: failure)

--- a/signals/generators/ios/templates/swift/methods/request.j2
+++ b/signals/generators/ios/templates/swift/methods/request.j2
@@ -1,30 +1,30 @@
-  {% set request_object_name = get_object_name(api.request_object, upper_camel_case=True) %}
-  {% set request_object = api.request_object %}
-  var obj = NSEntityDescription.insertNewObjectForEntityForName({{ request_object_name }}, inManagedObjectContext: sharedMgr.managedObjectStore.mainQueueManagedObjectContext)
-  {% for field in request_object.properties() %}
-    {% if field.field_type not in [VIDEO_FIELD, IMAGE_FIELD] %}
-    {% set field_name = get_proper_name(field.name) %}
-  obj.{{ field_name }} = {{ field_name }}
-    {% endif %}
-  {% endfor %}
-  {% set media_fields = get_media_fields(request_object.fields) %}
-  {% if media_fields|length > 0 %}
-  if ({{ media_field_check(media_fields) }}) {
-    var request = sharedMgr.multipartFormRequestWithObject(obj, method: RKRequestMethod{{ api.method|upper }}, path: "{{ api.url_path }}", parameters: nil, constructingBodyWithBlock: { (formData: AFMultipartFormData) -> () in
-     {% for media_field in media_fields %}
-     {% if media_field.field_type == VIDEO_FIELD %}
-      formData.appendPartWithFileURL({{ get_proper_name(media_field.name) }}, name: "{{ media_field.name }}", fileName: "{{ media_field.name }}.mp4", mimeType: "video/mp4", error: nil)
-     {% else %}
-      formData.appendPartWithFileData(UIImageJPEGRepresentation({{ get_proper_name(media_field.name) }}, 1), name: "{{ media_field.name }}", fileName: "{{ media_field.name }}.jpeg", mimeType: "image/jpeg", error: nil)
-     {% endif %}
-     {% endfor %}
-    })
+    {% set request_object_name = get_object_name(api.request_object, upper_camel_case=True) %}
+    {% set request_object = api.request_object %}
+    let obj = NSEntityDescription.insertNewObjectForEntityForName("{{ request_object_name }}", inManagedObjectContext: sharedMgr.managedObjectStore.mainQueueManagedObjectContext) as! {{ request_object_name }}
+    {% for field in request_object.properties() %}
+      {% if field.field_type not in [VIDEO_FIELD, IMAGE_FIELD] %}
+      {% set field_name = get_proper_name(field.name) %}
+    obj.{{ field_name }} = {{ field_name }}
+      {% endif %}
+    {% endfor %}
+    {% set media_fields = get_media_fields(request_object.fields) %}
+    {% if media_fields|length > 0 %}
+    if ({{ media_field_check(media_fields) }}) {
+      var request = sharedMgr.multipartFormRequestWithObject(obj, method: RKRequestMethod.{{ api.method|upper }}, path: "{{ api.url_path }}", parameters: nil, constructingBodyWithBlock: { (formData: AFMultipartFormData) -> () in
+       {% for media_field in media_fields %}
+       {% if media_field.field_type == VIDEO_FIELD %}
+        formData.appendPartWithFileURL({{ get_proper_name(media_field.name) }}, name: "{{ media_field.name }}", fileName: "{{ media_field.name }}.mp4", mimeType: "video/mp4", error: nil)
+       {% else %}
+        formData.appendPartWithFileData(UIImageJPEGRepresentation({{ get_proper_name(media_field.name) }}, 1), name: "{{ media_field.name }}", fileName: "{{ media_field.name }}.jpeg", mimeType: "image/jpeg", error: nil)
+       {% endif %}
+       {% endfor %}
+      })
 
-    var operation = sharedMgr.managedObjectRequestOperationWithRequest(request, managedObjectContext: nil, success: success, failure: failure)
-    sharedMgr.enqueueObjectRequestOperation(operation)
-  } else {
+      var operation = sharedMgr.managedObjectRequestOperationWithRequest(request, managedObjectContext: nil, success: success, failure: failure)
+      sharedMgr.enqueueObjectRequestOperation(operation)
+    } else {
   {%+ include 'methods/send_object.j2' %}
-  }
-  {% else %}
-  {% include 'methods/send_object.j2' %}
+    }
+    {% else %}
+    {% include 'methods/send_object.j2' %}
   {% endif %}

--- a/signals/generators/ios/templates/swift/methods/send_object.j2
+++ b/signals/generators/ios/templates/swift/methods/send_object.j2
@@ -1,7 +1,7 @@
 {% set object = "obj" if api.request_object else "nil" %}
 {% if ':id' in api.url_path %}
-  var formattedUrl = "{{ api.url_path|replace(':id', '\(theID)') }}"
-  sharedMgr.{{ api.method }}Object({{ object }}, path: formattedUrl, parameters: nil, success: success, failure: failure)
+    let formattedUrl = "{{ api.url_path|replace(':id', '\(theID)') }}"
+    sharedMgr.{{ api.method }}Object({{ object }}, path: formattedUrl, parameters: nil, success: success, failure: failure)
 {% else %}
-  sharedMgr.{{ api.method }}Object({{ object }}, path: "{{ api.url_path }}", parameters: nil, success: success, failure: failure)
+    sharedMgr.{{ api.method }}Object({{ object }}, path: "{{ api.url_path }}", parameters: nil, success: success, failure: failure)
 {% endif %}

--- a/signals/generators/ios/templates/swift/relationship_mapping.j2
+++ b/signals/generators/ios/templates/swift/relationship_mapping.j2
@@ -1,3 +1,3 @@
-  {% set from_mapping_name = get_object_name(data_object) %}
-  {% set to_mapping_name = get_object_name(relationship.related_object) %}
-  {{ from_mapping_name }}Mapping.addPropertyMapping(RKRelationshipMapping.relationshipMappingFromKeyPath("{{ relationship.name }}", toKeyPath: "{{ get_proper_name(relationship.name) }}", withMapping: {{ to_mapping_name }}Mapping))
+    {% set from_mapping_name = get_object_name(data_object) %}
+    {% set to_mapping_name = get_object_name(relationship.related_object) %}
+    {{ from_mapping_name }}Mapping.addPropertyMapping(RKRelationshipMapping(fromKeyPath: "{{ relationship.name }}", toKeyPath: "{{ get_proper_name(relationship.name) }}", withMapping: {{ to_mapping_name }}Mapping))

--- a/tests/generators/ios/objc/files/DataModel.h
+++ b/tests/generators/ios/objc/files/DataModel.h
@@ -41,8 +41,6 @@
 - (void) getLoginWithSuccess:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure;
 
 
-- (void) getAllLoginWithUsername:(NSString*)username password:(NSString*)password success:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure;
-
 - (void) setup:(id<DataModelDelegate>)delegate;
 
 @end

--- a/tests/generators/ios/objc/files/DataModel.m
+++ b/tests/generators/ios/objc/files/DataModel.m
@@ -104,11 +104,5 @@
   [sharedMgr getObject:nil path:@"login/" parameters:nil success:success failure:failure];
 }
 
-- (void) getAllLoginWithUsername:(NSString*)username password:(NSString*)password success:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure {
-  RKObjectManager* sharedMgr = [RKObjectManager sharedManager];
-  [sharedMgr.HTTPClient setAuthorizationHeaderWithUsername:username password:password];
-  sharedMgr.requestSerializationMIMEType = RKMIMETypeFormURLEncoded;
-  [sharedMgr getObjectsAtPath:@"login/" parameters:nil success:success failure:failure];
-}
 
 @end

--- a/tests/generators/ios/swift/files/APIMethod.swift
+++ b/tests/generators/ios/swift/files/APIMethod.swift
@@ -1,6 +1,6 @@
-func getPostWithSuccess(success: RestKitSuccess, failure: RestKitError) {
-  var sharedMgr = RKObjectManager.sharedManager()
-  sharedMgr.requestSerializationMIMEType = RKMIMETypeJSON
-  sharedMgr.HTTPClient.setDefaultHeader("Authorization", value: NSString.stringWithFormat("Bearer \(_delegate.getAccessToken())"))
-  sharedMgr.getObject(nil, path: "post/", parameters: nil, success: success, failure: failure)
-}
+  func getPostWithSuccess(success: RestKitSuccess, failure: RestKitError) {
+    let sharedMgr = RKObjectManager.sharedManager()
+    sharedMgr.requestSerializationMIMEType = RKMIMETypeJSON
+    sharedMgr.HTTPClient.setDefaultHeader("Authorization", value: NSString.stringWithFormat("Bearer \(_delegate.getAccessToken())"))
+    sharedMgr.getObject(nil, path: "post/", parameters: nil, success: success, failure: failure)
+  }

--- a/tests/generators/ios/swift/files/DataModel.swift
+++ b/tests/generators/ios/swift/files/DataModel.swift
@@ -10,109 +10,105 @@ import RestKit
 typealias RestKitSuccess = (operation: RKObjectRequestOperation!, result: RKMappingResult!) -> Void
 typealias RestKitError = (operation: RKObjectRequestOperation!, error: NSError!) -> Void
 
-@objc public class DataModel: NSObject {
-  var getBaseURLString: String?
-  var getAccessToken: String?
+protocol DataModelDelegate {
+  func getBaseURLString() -> String
+  func getAccessToken() -> String
+}
 
-  class var sharedDataModel: DataModel {
+class DataModel: NSObject {
+  var delegate: DataModelDelegate?
+
+  class func sharedDataModel() -> DataModel {
     struct Static {
-      static var __sharedDataModel = nil
+      static var __sharedDataModel: DataModel? = nil
       static var onceToken: dispatch_once_t = 0
     }
 
     dispatch_once(&Static.onceToken) {
-      __sharedDataModel = DataModel.alloc().init()
+      Static.__sharedDataModel = DataModel.init()
     }
 
     return Static.__sharedDataModel!
   }
-}
 
-func setup(delegate: DataModelDelegate) {
-  // Initialize RestKit
-  _delegate = delegate;
-  assert(_delegate != nil, "delegate parameter cannot be nil")
-  var baseURL = NSURL.URLWithString(_delegate.getBaseURLString())
-  var objectManager = RKObjectManager.managerWithBaseURL(baseURL)
+  func setup(delegate: DataModelDelegate) {
+    // Initialize RestKit
+    let _delegate = delegate;
+    let baseURL = NSURL(string: _delegate.getBaseURLString())
+    let objectManager = RKObjectManager(baseURL: baseURL)
 
-  // Enable Activity Indicator Spinner
-  AFNetworkActivityIndicatorManager.sharedManager().enabled = true;
+    // Enable Activity Indicator Spinner
+    AFNetworkActivityIndicatorManager.sharedManager().enabled = true;
 
-  // Initialize managed object store
-  var managedObjectModel = NSManagedObjectModel.mergedModelFromBundles(nil)
-  var managedObjectStore = RKManagedObjectStore.alloc().initWithManagedObjectModel(managedObjectModel)
+    // Initialize managed object store
+    let managedObjectModel = NSManagedObjectModel.mergedModelFromBundles(nil)
+    let managedObjectStore = RKManagedObjectStore(managedObjectModel: managedObjectModel)
 
-  objectManager.managedObjectStore = managedObjectStore;
+    objectManager.managedObjectStore = managedObjectStore;
 
-  // MARK: RestKit Entity Mappings
-  var loginResponseMapping = RKEntityMapping.mappingForEntityForName(LoginResponse, inManagedObjectStore: managedObjectStore)
-  loginResponseMapping.addAttributeMappingsFromDictionary([ "client_secret": "clientSecret", "client_id": "clientId" ])
+    // MARK: RestKit Entity Mappings
+    let loginResponseMapping = RKEntityMapping(forEntityForName: "LoginResponse", inManagedObjectStore: managedObjectStore)
+    loginResponseMapping.addAttributeMappingsFromDictionary([ "client_secret": "clientSecret", "client_id": "clientId" ])
 
-  var signUpResponseMapping = RKEntityMapping.mappingForEntityForName(SignUpResponse, inManagedObjectStore: managedObjectStore)
-  signUpResponseMapping.addAttributeMappingsFromDictionary([ "username": "username", "client_secret": "clientSecret", "fullname": "fullname", "email": "email", "client_id": "clientId" ])
+    let signUpResponseMapping = RKEntityMapping(forEntityForName: "SignUpResponse", inManagedObjectStore: managedObjectStore)
+    signUpResponseMapping.addAttributeMappingsFromDictionary([ "username": "username", "client_secret": "clientSecret", "fullname": "fullname", "email": "email", "client_id": "clientId" ])
 
-  var signUpRequestMapping = RKEntityMapping.mappingForEntityForName(SignUpRequest, inManagedObjectStore: managedObjectStore)
-  signUpRequestMapping.addAttributeMappingsFromDictionary([ "username": "username", "fullname": "fullname", "password": "password", "email": "email" ])
+    let signUpRequestMapping = RKEntityMapping(forEntityForName: "SignUpRequest", inManagedObjectStore: managedObjectStore)
+    signUpRequestMapping.addAttributeMappingsFromDictionary([ "username": "username", "fullname": "fullname", "password": "password", "email": "email" ])
 
 
-  // MARK: RestKit Entity Relationship Mappings
-  // We place the relationship mappings after the entities so that we don't need to worry about ordering
+    // MARK: RestKit Entity Relationship Mappings
+    // We place the relationship mappings after the entities so that we don't need to worry about ordering
 
-  // MARK: RestKit URL Descriptors
-  var signUpPostRequestDescriptor = RKRequestDescriptor.requestDescriptorWithMapping(signUpRequestMapping.inverseMapping(), objectClass: SignUpRequest.self, rootKeyPath: nil, method: RKRequestMethodPOST)
-  objectManager.addRequestDescriptor(signUpPostRequestDescriptor)
+    // MARK: RestKit URL Descriptors
+    let signUpPostRequestDescriptor = RKRequestDescriptor(mapping: signUpRequestMapping.inverseMapping(), objectClass: SignUpRequest.self, rootKeyPath: nil, method: RKRequestMethod.POST)
+    objectManager.addRequestDescriptor(signUpPostRequestDescriptor)
 
-  var signUpPostResponseDescriptor = RKResponseDescriptor.responseDescriptorWithMapping(signUpResponseMapping, method: RKRequestMethodPOST, pathPattern: "sign_up/", keyPath: nil, statusCodes: RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful))
-  objectManager.addResponseDescriptor(signUpPostResponseDescriptor)
+    let signUpPostResponseDescriptor = RKResponseDescriptor(mapping: signUpResponseMapping, method: RKRequestMethod.POST, pathPattern: "sign_up/", keyPath: nil, statusCodes: RKStatusCodeIndexSetForClass(RKStatusCodeClass.Successful))
+    objectManager.addResponseDescriptor(signUpPostResponseDescriptor)
 
-  var loginGetResponseDescriptor = RKResponseDescriptor.responseDescriptorWithMapping(loginResponseMapping, method: RKRequestMethodGET, pathPattern: "login/", keyPath: "results", statusCodes: RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful))
-  objectManager.addResponseDescriptor(loginGetResponseDescriptor)
+    let loginGetResponseDescriptor = RKResponseDescriptor(mapping: loginResponseMapping, method: RKRequestMethod.GET, pathPattern: "login/", keyPath: "results", statusCodes: RKStatusCodeIndexSetForClass(RKStatusCodeClass.Successful))
+    objectManager.addResponseDescriptor(loginGetResponseDescriptor)
 
 
-  /**
-   Complete Core Data stack initialization
-   */
-  managedObjectStore.createPersistentStoreCoordinator()
-  var storePath = RKApplicationDataDirectory().stringByAppendingPathComponent("TestProject.sqlite")
-  var error: NSError
-  var persistentStore = managedObjectStore.addSQLitePersistentStoreAtPath(storePath, fromSeedDatabaseAtPath: nil, withConfiguration: nil, options: nil, error: &error)
+    /**
+    Complete Core Data stack initialization
+    */
+    managedObjectStore.createPersistentStoreCoordinator()
+    let storePath = (RKApplicationDataDirectory() as NSString).stringByAppendingPathComponent("TestProject.sqlite")
 
-  // Problem creating persistent store, wipe it since there was probably a core data change
-  if (persistentStore == nil) {
-    NSFileManager.defaultManager().removeItemAtPath(storePath, error: nil)
-    persistentStore = managedObjectStore.addSQLitePersistentStoreAtPath(storePath, fromSeedDatabaseAtPath: nil, withConfiguration: nil, options: nil, error: &error)
+    do {
+      try managedObjectStore.addSQLitePersistentStoreAtPath(storePath, fromSeedDatabaseAtPath: nil, withConfiguration: nil, options: nil)
+    } catch {
+      // Problem creating persistent store, wipe it since there was probably a core data change
+      // Causes runtime crash if still unable to create persistant storage
+      try! NSFileManager.defaultManager().removeItemAtPath(storePath)
+      try! managedObjectStore.addSQLitePersistentStoreAtPath(storePath, fromSeedDatabaseAtPath: nil, withConfiguration: nil, options: nil)
+    }
+
+    // Create the managed object contexts
+    managedObjectStore.createManagedObjectContexts()
+
+    // Configure a managed object cache to ensure we do not create duplicate objects
+    managedObjectStore.managedObjectCache = RKInMemoryManagedObjectCache(managedObjectContext: managedObjectStore.persistentStoreManagedObjectContext)
   }
 
-  assert(persistentStore, "Failed to add persistent store with error: \(error)")
+  // MARK: API Calls
+  func postSignUpWithUsername(username: String, fullname: String, password: String, email: String, success: RestKitSuccess, failure: RestKitError) {
+    let sharedMgr = RKObjectManager.sharedManager()
+    sharedMgr.requestSerializationMIMEType = RKMIMETypeJSON
+    let obj = NSEntityDescription.insertNewObjectForEntityForName("SignUpRequest", inManagedObjectContext: sharedMgr.managedObjectStore.mainQueueManagedObjectContext) as! SignUpRequest
+    obj.username = username
+    obj.fullname = fullname
+    obj.password = password
+    obj.email = email
+    sharedMgr.postObject(obj, path: "sign_up/", parameters: nil, success: success, failure: failure)
+  }
 
-  // Create the managed object contexts
-  managedObjectStore.createManagedObjectContexts()
+  func getLoginWithSuccess(success: RestKitSuccess, failure: RestKitError) {
+    let sharedMgr = RKObjectManager.sharedManager()
+    sharedMgr.requestSerializationMIMEType = RKMIMETypeJSON
+    sharedMgr.getObject(nil, path: "login/", parameters: nil, success: success, failure: failure)
+  }
 
-  // Configure a managed object cache to ensure we do not create duplicate objects
-  managedObjectStore.managedObjectCache = RKInMemoryManagedObjectCache.alloc().initWithManagedObjectContext(managedObjectStore.persistentStoreManagedObjectContext)
-}
-
-// MARK: API Calls
-func postSignUpWithUsername(username: String, fullname: String, password: String, email: String, success: RestKitSuccess, failure: RestKitError) {
-  var sharedMgr = RKObjectManager.sharedManager()
-  sharedMgr.requestSerializationMIMEType = RKMIMETypeJSON
-  var obj = NSEntityDescription.insertNewObjectForEntityForName(SignUpRequest, inManagedObjectContext: sharedMgr.managedObjectStore.mainQueueManagedObjectContext)
-  obj.username = username
-  obj.fullname = fullname
-  obj.password = password
-  obj.email = email
-  sharedMgr.postObject(obj, path: "sign_up/", parameters: nil, success: success, failure: failure)
-}
-
-func getLoginWithSuccess(success: RestKitSuccess, failure: RestKitError) {
-  var sharedMgr = RKObjectManager.sharedManager()
-  sharedMgr.requestSerializationMIMEType = RKMIMETypeJSON
-  sharedMgr.getObject(nil, path: "login/", parameters: nil, success: success, failure: failure)
-}
-
-func getAllLoginWithUsername(username: String, password: String, success: RestKitSuccess, failure: RestKitFailure) {
-  var sharedMgr = RKObjectManager.sharedManager()
-  sharedMgr.HTTPClient.setAuthorizationHeaderWithUsername(username, password: password)
-  sharedMgr.requestSerializationMIMEType = RKMIMETypeFormURLEncoded
-  sharedMgr.getObjectsAtPath("login/", parameters: nil, success: success, failure: failure)
 }

--- a/tests/generators/ios/swift/files/EntityMapping.swift
+++ b/tests/generators/ios/swift/files/EntityMapping.swift
@@ -1,3 +1,3 @@
-  var postResponseMapping = RKEntityMapping.mappingForEntityForName(PostResponse, inManagedObjectStore: managedObjectStore)
-  postResponseMapping.identificationAttributes = ["\(theID)"]
-  postResponseMapping.addAttributeMappingsFromDictionary([ "body": "body", "id": "theID", "title": "title" ])
+    let postResponseMapping = RKEntityMapping(forEntityForName: "PostResponse", inManagedObjectStore: managedObjectStore)
+    postResponseMapping.identificationAttributes = ["\(theID)"]
+    postResponseMapping.addAttributeMappingsFromDictionary([ "body": "body", "id": "theID", "title": "title" ])

--- a/tests/generators/ios/swift/files/GetResponseDescriptor.swift
+++ b/tests/generators/ios/swift/files/GetResponseDescriptor.swift
@@ -1,2 +1,2 @@
-  var postGetResponseDescriptor = RKResponseDescriptor.responseDescriptorWithMapping(postResponseMapping, method: RKRequestMethodGET, pathPattern: "post/", keyPath: "results", statusCodes: RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful))
-  objectManager.addResponseDescriptor(postGetResponseDescriptor)
+    let postGetResponseDescriptor = RKResponseDescriptor(mapping: postResponseMapping, method: RKRequestMethod.GET, pathPattern: "post/", keyPath: "results", statusCodes: RKStatusCodeIndexSetForClass(RKStatusCodeClass.Successful))
+    objectManager.addResponseDescriptor(postGetResponseDescriptor)

--- a/tests/generators/ios/swift/files/MethodParameters.swift
+++ b/tests/generators/ios/swift/files/MethodParameters.swift
@@ -1,8 +1,8 @@
-  var queryParams = NSMutableDictionary(capacity: 2)
-  if (userId) {
-    queryParams.setObject(userId, forKey: "user_id")
-  }
-  if (title) {
-    queryParams.setObject(title, forKey: "title")
-  }
-  sharedMgr.getObjectsAtPath("post/", parameters: queryParams, success: success, failure: failure)
+    let queryParams = NSMutableDictionary(capacity: 2)
+    if (userId) {
+      queryParams.setObject(userId, forKey: "user_id")
+    }
+    if (title) {
+      queryParams.setObject(title, forKey: "title")
+    }
+    sharedMgr.getObjectsAtPath("post/", parameters: queryParams, success: success, failure: failure)

--- a/tests/generators/ios/swift/files/MethodRequest.swift
+++ b/tests/generators/ios/swift/files/MethodRequest.swift
@@ -1,4 +1,4 @@
-  var obj = NSEntityDescription.insertNewObjectForEntityForName(PostRequest, inManagedObjectContext: sharedMgr.managedObjectStore.mainQueueManagedObjectContext)
-  obj.body = body
-  obj.title = title
-  sharedMgr.postObject(obj, path: "post/", parameters: nil, success: success, failure: failure)
+    let obj = NSEntityDescription.insertNewObjectForEntityForName("PostRequest", inManagedObjectContext: sharedMgr.managedObjectStore.mainQueueManagedObjectContext) as! PostRequest
+    obj.body = body
+    obj.title = title
+    sharedMgr.postObject(obj, path: "post/", parameters: nil, success: success, failure: failure)

--- a/tests/generators/ios/swift/files/MethodRequestWithMediaFields.swift
+++ b/tests/generators/ios/swift/files/MethodRequestWithMediaFields.swift
@@ -1,14 +1,14 @@
-  var obj = NSEntityDescription.insertNewObjectForEntityForName(PostRequest, inManagedObjectContext: sharedMgr.managedObjectStore.mainQueueManagedObjectContext)
-  obj.body = body
-  obj.title = title
-  if (video != nil || thumbnail != nil) {
-    var request = sharedMgr.multipartFormRequestWithObject(obj, method: RKRequestMethodPOST, path: "post/", parameters: nil, constructingBodyWithBlock: { (formData: AFMultipartFormData) -> () in
-      formData.appendPartWithFileURL(video, name: "video", fileName: "video.mp4", mimeType: "video/mp4", error: nil)
-      formData.appendPartWithFileData(UIImageJPEGRepresentation(thumbnail, 1), name: "thumbnail", fileName: "thumbnail.jpeg", mimeType: "image/jpeg", error: nil)
-    })
+    let obj = NSEntityDescription.insertNewObjectForEntityForName("PostRequest", inManagedObjectContext: sharedMgr.managedObjectStore.mainQueueManagedObjectContext) as! PostRequest
+    obj.body = body
+    obj.title = title
+    if (video != nil || thumbnail != nil) {
+      var request = sharedMgr.multipartFormRequestWithObject(obj, method: RKRequestMethod.POST, path: "post/", parameters: nil, constructingBodyWithBlock: { (formData: AFMultipartFormData) -> () in
+        formData.appendPartWithFileURL(video, name: "video", fileName: "video.mp4", mimeType: "video/mp4", error: nil)
+        formData.appendPartWithFileData(UIImageJPEGRepresentation(thumbnail, 1), name: "thumbnail", fileName: "thumbnail.jpeg", mimeType: "image/jpeg", error: nil)
+      })
 
-    var operation = sharedMgr.managedObjectRequestOperationWithRequest(request, managedObjectContext: nil, success: success, failure: failure)
-    sharedMgr.enqueueObjectRequestOperation(operation)
-  } else {
-    sharedMgr.postObject(obj, path: "post/", parameters: nil, success: success, failure: failure)
-  }
+      var operation = sharedMgr.managedObjectRequestOperationWithRequest(request, managedObjectContext: nil, success: success, failure: failure)
+      sharedMgr.enqueueObjectRequestOperation(operation)
+    } else {
+      sharedMgr.postObject(obj, path: "post/", parameters: nil, success: success, failure: failure)
+    }

--- a/tests/generators/ios/swift/files/PatchRequestDescriptor.swift
+++ b/tests/generators/ios/swift/files/PatchRequestDescriptor.swift
@@ -1,4 +1,4 @@
-  var postRequestMappingInverse = postRequestMapping.inverseMapping()
-  postRequestMappingInverse.assignsDefaultValueForMissingAttributes = false
-  var postWithIdPatchRequestDescriptor = RKRequestDescriptor.requestDescriptorWithMapping(postRequestMapping.inverseMapping(), objectClass: PostRequest.self, rootKeyPath: nil, method: RKRequestMethodPATCH)
-  objectManager.addRequestDescriptor(postWithIdPatchRequestDescriptor)
+    let postRequestMappingInverse = postRequestMapping.inverseMapping()
+    postRequestMappingInverse.assignsDefaultValueForMissingAttributes = false
+    let postWithIdPatchRequestDescriptor = RKRequestDescriptor(mapping: postRequestMapping.inverseMapping(), objectClass: PostRequest.self, rootKeyPath: nil, method: RKRequestMethod.PATCH)
+    objectManager.addRequestDescriptor(postWithIdPatchRequestDescriptor)

--- a/tests/generators/ios/swift/files/PostRequestDescriptor.swift
+++ b/tests/generators/ios/swift/files/PostRequestDescriptor.swift
@@ -1,2 +1,2 @@
-  var postPostRequestDescriptor = RKRequestDescriptor.requestDescriptorWithMapping(postRequestMapping.inverseMapping(), objectClass: PostRequest.self, rootKeyPath: nil, method: RKRequestMethodPOST)
-  objectManager.addRequestDescriptor(postPostRequestDescriptor)
+    let postPostRequestDescriptor = RKRequestDescriptor(mapping: postRequestMapping.inverseMapping(), objectClass: PostRequest.self, rootKeyPath: nil, method: RKRequestMethod.POST)
+    objectManager.addRequestDescriptor(postPostRequestDescriptor)

--- a/tests/generators/ios/swift/files/RelationshipMapping.swift
+++ b/tests/generators/ios/swift/files/RelationshipMapping.swift
@@ -1,1 +1,1 @@
-  postResponseMapping.addPropertyMapping(RKRelationshipMapping.relationshipMappingFromKeyPath("user", toKeyPath: "user", withMapping: userResponseMapping))
+    postResponseMapping.addPropertyMapping(RKRelationshipMapping(fromKeyPath: "user", toKeyPath: "user", withMapping: userResponseMapping))

--- a/tests/generators/ios/swift/files/SendObject.swift
+++ b/tests/generators/ios/swift/files/SendObject.swift
@@ -1,1 +1,1 @@
-  sharedMgr.postObject(obj, path: "post/", parameters: nil, success: success, failure: failure)
+    sharedMgr.postObject(obj, path: "post/", parameters: nil, success: success, failure: failure)

--- a/tests/generators/ios/swift/files/SendObjectWithId.swift
+++ b/tests/generators/ios/swift/files/SendObjectWithId.swift
@@ -1,2 +1,2 @@
-  var formattedUrl = "post/\(theID)/"
-  sharedMgr.patchObject(obj, path: formattedUrl, parameters: nil, success: success, failure: failure)
+    let formattedUrl = "post/\(theID)/"
+    sharedMgr.patchObject(obj, path: formattedUrl, parameters: nil, success: success, failure: failure)


### PR DESCRIPTION
@rmutter @leemcdole  Updated the syntax for the swift templates. Also removed the `getAllLoginWithUsername` function that was created every time. I built a working swift demo app from `test_schema` with no errors/warnings, but some problems might surface once `relationshipConflictFix` gets merged in and we're able to build off of more intense schemas since the test schema doesn't cover every path in the templates.