### PR TITLE
Generalize field name conversion to facilitate different reserved keywords in Obj-C and Swift. This also closes #26.

### DIFF
--- a/signals/generators/ios/conversion.py
+++ b/signals/generators/ios/conversion.py
@@ -1,41 +1,44 @@
 """
 Methods to translate the schema variable names and types to desired language's names and types.
 """
+from signals.logging import warn
+import reserved_mappings
 
-# More listed here: http://www.binpress.com/tutorial/objective-c-reserved-keywords/43
-RESERVED_MAPPINGS = {
-    "auto": "isAuto",
-    "default": "isDefault",
-    "description": "theDescription",
-    "id": "theID",
-    "register": "theRegister",
-    "restrict": "shouldRestrict",
-    "super": "isSuper",
-    "volatile": "isVolatile"
-}
+class BaseConverter(object):
+
+    # Some field names are reserved in target language
+    @classmethod
+    def sanitize_field_name(cls, field_name):
+        if field_name in cls.reserved_mappings:
+            converted_name = cls.reserved_mappings[field_name]
+            warn("{} is a reserved keyword in {} and is now being converted to {}".format(field_name, cls.language, converted_name))
+            return converted_name
+        else:
+            return field_name
+
+    # Changes a Python formatted variable name to conform to target language
+    @classmethod
+    def format_name(cls, python_variable_name, capitalize_first=False):
+        words = python_variable_name.split('_')
+
+        def upper_camel_case(words_to_capitalize):
+            return "".join(word.capitalize() for word in words_to_capitalize)
+
+        if capitalize_first:
+            return upper_camel_case(words)
+        else:
+            return words[0] + upper_camel_case(words[1:])
+
+    @classmethod
+    def get_proper_name(cls, name, capitalize_first=False):
+        proper_name = cls.sanitize_field_name(name)
+        return cls.format_name(proper_name, capitalize_first=capitalize_first)
 
 
-# Changes a Python variable name to an Objective-C/Swift version
-def python_to_objc_variable(python_variable_name, capitalize_first=False):
-    words = python_variable_name.split('_')
+class ObjectiveCConverter(BaseConverter):
+    language = "Objective-C"
+    reserved_mappings = reserved_mappings.OBJC_RESERVED_MAPPINGS
 
-    def upper_camel_case(words_to_capitalize):
-        return "".join(word.capitalize() for word in words_to_capitalize)
-
-    if capitalize_first:
-        return upper_camel_case(words)
-    else:
-        return words[0] + upper_camel_case(words[1:])
-
-
-# Some field names are reserved in Objective C
-def sanitize_field_name(field_name):
-    if field_name in RESERVED_MAPPINGS:
-        return RESERVED_MAPPINGS[field_name]
-    else:
-        return field_name
-
-
-def get_proper_name(name, capitalize_first=False):
-    proper_name = sanitize_field_name(name)
-    return python_to_objc_variable(proper_name, capitalize_first=capitalize_first)
+class SwiftConverter(BaseConverter):
+    language = "Swift"
+    reserved_mappings = reserved_mappings.SWIFT_RESERVED_MAPPINGS

--- a/signals/generators/ios/conversion.py
+++ b/signals/generators/ios/conversion.py
@@ -4,6 +4,7 @@ Methods to translate the schema variable names and types to desired language's n
 from signals.logging import warn
 import reserved_mappings
 
+
 class BaseConverter(object):
 
     # Some field names are reserved in target language
@@ -11,7 +12,8 @@ class BaseConverter(object):
     def sanitize_field_name(cls, field_name):
         if field_name in cls.reserved_mappings:
             converted_name = cls.reserved_mappings[field_name]
-            warn("{} is a reserved keyword in {} and is now being converted to {}".format(field_name, cls.language, converted_name))
+            warn("{} is a reserved keyword in {} and is now being converted to {}"
+                 .format(field_name, cls.language, converted_name))
             return converted_name
         else:
             return field_name
@@ -38,6 +40,7 @@ class BaseConverter(object):
 class ObjectiveCConverter(BaseConverter):
     language = "Objective-C"
     reserved_mappings = reserved_mappings.OBJC_RESERVED_MAPPINGS
+
 
 class SwiftConverter(BaseConverter):
     language = "Swift"

--- a/signals/generators/ios/core_data.py
+++ b/signals/generators/ios/core_data.py
@@ -5,7 +5,7 @@ import os
 from xml.dom import minidom
 from lxml import etree
 from signals.parser.fields import Relationship, Field
-from signals.generators.ios.conversion import ObjectiveCConverter.get_proper_name
+from signals.generators.ios.conversion import ObjectiveCConverter
 
 DATA_TYPES = {
     Field.DATE: "Date",
@@ -140,7 +140,8 @@ def add_relationships(model, objects):
                 add_M2M_relationships(first_entity, second_entity, relationship.name,
                                       get_word_plural(first_entity_name))
             elif relationship.relationship_type == Relationship.ONE_TO_ONE:
-                add_O2O_relationships(first_entity, second_entity, ObjectiveCConverter.get_proper_name(relationship.name),
+                add_O2O_relationships(first_entity, second_entity,
+                                      ObjectiveCConverter.get_proper_name(relationship.name),
                                       first_entity_name)
             elif relationship.relationship_type == Relationship.MANY_TO_ONE:
                 """

--- a/signals/generators/ios/core_data.py
+++ b/signals/generators/ios/core_data.py
@@ -5,7 +5,7 @@ import os
 from xml.dom import minidom
 from lxml import etree
 from signals.parser.fields import Relationship, Field
-from signals.generators.ios.conversion import get_proper_name
+from signals.generators.ios.conversion import ObjectiveCConverter.get_proper_name
 
 DATA_TYPES = {
     Field.DATE: "Date",
@@ -140,7 +140,7 @@ def add_relationships(model, objects):
                 add_M2M_relationships(first_entity, second_entity, relationship.name,
                                       get_word_plural(first_entity_name))
             elif relationship.relationship_type == Relationship.ONE_TO_ONE:
-                add_O2O_relationships(first_entity, second_entity, get_proper_name(relationship.name),
+                add_O2O_relationships(first_entity, second_entity, ObjectiveCConverter.get_proper_name(relationship.name),
                                       first_entity_name)
             elif relationship.relationship_type == Relationship.MANY_TO_ONE:
                 """
@@ -153,7 +153,7 @@ def add_relationships(model, objects):
                 conflicting = conflicting_entity_name(data_object.relationships, relationship)
                 entity_label = relationship.name if conflicting else first_entity_name
                 add_M2O_relationship(first_entity, second_entity, get_word_plural(entity_label),
-                                     get_proper_name(relationship.name))
+                                     ObjectiveCConverter.get_proper_name(relationship.name))
 
 
 # Adds attributes to the given entity for its name and type

--- a/signals/generators/ios/ios_template_methods.py
+++ b/signals/generators/ios/ios_template_methods.py
@@ -3,7 +3,7 @@ Methods to be used in the iOS generator's templates.
 """
 import re
 from signals.generators.base.base_template_methods import BaseTemplateMethods
-from signals.generators.ios.conversion import get_proper_name
+from signals.generators.ios.conversion import ObjectiveCConverter.get_proper_name
 from signals.generators.ios.objc.parameters import ObjCParameter
 from signals.generators.ios.swift.parameters import SwiftParameter
 from signals.parser.api import API
@@ -40,7 +40,7 @@ class iOSTemplateMethods(BaseTemplateMethods):
         request_object = iOSTemplateMethods.get_api_request_object(api)
         if request_object and len(request_object.properties()) > 0:
             first_field = request_object.properties()[0]
-            first_parameter_name = get_proper_name(first_field.name, capitalize_first=True)
+            first_parameter_name = ObjectiveCConverter.get_proper_name(first_field.name, capitalize_first=True)
         elif ObjCParameter.create_id_parameter(api.url_path, request_object) is not None:
             first_parameter_name = "TheID"
         elif SwiftParameter.create_id_parameter(api.url_path, request_object) is not None:
@@ -57,5 +57,5 @@ class iOSTemplateMethods(BaseTemplateMethods):
 
     @staticmethod
     def media_field_check(fields):
-        statements = ["{} != nil".format(get_proper_name(field.name)) for field in fields]
+        statements = ["{} != nil".format(ObjectiveCConverter.get_proper_name(field.name)) for field in fields]
         return " || ".join(statements)

--- a/signals/generators/ios/ios_template_methods.py
+++ b/signals/generators/ios/ios_template_methods.py
@@ -3,7 +3,7 @@ Methods to be used in the iOS generator's templates.
 """
 import re
 from signals.generators.base.base_template_methods import BaseTemplateMethods
-from signals.generators.ios.conversion import ObjectiveCConverter.get_proper_name
+from signals.generators.ios.conversion import ObjectiveCConverter
 from signals.generators.ios.objc.parameters import ObjCParameter
 from signals.generators.ios.swift.parameters import SwiftParameter
 from signals.parser.api import API

--- a/signals/generators/ios/objc/template.py
+++ b/signals/generators/ios/objc/template.py
@@ -1,6 +1,6 @@
 import shutil
 from signals.generators.base.base_template import BaseTemplate
-from signals.generators.ios.conversion import get_proper_name, sanitize_field_name
+from signals.generators.ios.conversion import ObjectiveCConverter
 from signals.generators.ios.objc.template_methods import ObjectiveCTemplateMethods
 from signals.parser.fields import Field
 
@@ -25,9 +25,9 @@ class ObjectiveCTemplate(BaseTemplate):
             'project_name': self.project_name,
             'VIDEO_FIELD': Field.VIDEO,
             'IMAGE_FIELD': Field.IMAGE,
-            'get_proper_name': get_proper_name,
+            'get_proper_name': ObjectiveCConverter.get_proper_name,
             'request_objects': self.get_request_objects(self.schema.data_objects),
-            'sanitize_field_name': sanitize_field_name
+            'sanitize_field_name': ObjectiveCConverter.sanitize_field_name
         })
 
     def copy_data_models(self):

--- a/signals/generators/ios/objc/template_methods.py
+++ b/signals/generators/ios/objc/template_methods.py
@@ -1,4 +1,4 @@
-from signals.generators.ios.conversion import ObjectiveCConverter.get_proper_name
+from signals.generators.ios.conversion import ObjectiveCConverter
 from signals.generators.ios.ios_template_methods import iOSTemplateMethods
 from signals.generators.ios.objc.parameters import ObjCParameter
 from signals.parser.api import GetAPI

--- a/signals/generators/ios/objc/template_methods.py
+++ b/signals/generators/ios/objc/template_methods.py
@@ -1,4 +1,4 @@
-from signals.generators.ios.conversion import get_proper_name
+from signals.generators.ios.conversion import ObjectiveCConverter.get_proper_name
 from signals.generators.ios.ios_template_methods import iOSTemplateMethods
 from signals.generators.ios.objc.parameters import ObjCParameter
 from signals.parser.api import GetAPI
@@ -45,7 +45,7 @@ class ObjectiveCTemplateMethods(iOSTemplateMethods):
         attribute_mapping_string = ""
         for index, field in enumerate(fields):
             leading_comma = '' if index == 0 else ', '
-            objc_variable_name = get_proper_name(field.name)
+            objc_variable_name = ObjectiveCConverter.get_proper_name(field.name)
             attribute_mapping_string += '{}@"{}": @"{}"'.format(leading_comma, field.name, objc_variable_name)
         return attribute_mapping_string
 
@@ -53,7 +53,7 @@ class ObjectiveCTemplateMethods(iOSTemplateMethods):
     def create_parameter_signature(parameters):
         method_parts = []
         for index, method_field in enumerate(parameters):
-            objc_variable_name = get_proper_name(method_field.name)
+            objc_variable_name = ObjectiveCConverter.get_proper_name(method_field.name)
             parameter_signature = "({}){}".format(method_field.objc_type, objc_variable_name)
             # If this isn't the first parameter, also include the variable name before the type
             if index > 0:

--- a/signals/generators/ios/reserved_mappings.py
+++ b/signals/generators/ios/reserved_mappings.py
@@ -15,7 +15,7 @@ OBJC_RESERVED_MAPPINGS = {
     "int": "isInt",
     "long": "isLong"
 }
-
+# Reserved name in Swift
 SWIFT_RESERVED_MAPPINGS = {
     "class": "_class",
     "func": "_func",

--- a/signals/generators/ios/reserved_mappings.py
+++ b/signals/generators/ios/reserved_mappings.py
@@ -1,6 +1,7 @@
 """
 Reserved keywords in respective languages
 """
+# Reserved name is Objective-C
 # More listed here: http://www.binpress.com/tutorial/objective-c-reserved-keywords/43
 OBJC_RESERVED_MAPPINGS = {
     "auto": "isAuto",
@@ -20,14 +21,5 @@ SWIFT_RESERVED_MAPPINGS = {
     "func": "_func",
     "init": "_init",
     "id": "theID"
-    # "auto": "isAuto",
-    # "default": "isDefault",
-    # "description": "theDescription",
-    # "id": "theID",
-    # "register": "theRegister",
-    # "restrict": "shouldRestrict",
-    # "super": "isSuper",
-    # "volatile": "isVolatile",
-    # "int": "isInt",
-    # "long": "isLong"
+    # more to be added
 }

--- a/signals/generators/ios/reserved_mappings.py
+++ b/signals/generators/ios/reserved_mappings.py
@@ -16,7 +16,6 @@ OBJC_RESERVED_MAPPINGS = {
     "long": "isLong"
 }
 
-# More listed here: https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/doc/uid/TP40014097-CH30-ID412
 SWIFT_RESERVED_MAPPINGS = {
     "class": "_class",
     "func": "_func",

--- a/signals/generators/ios/reserved_mappings.py
+++ b/signals/generators/ios/reserved_mappings.py
@@ -1,0 +1,24 @@
+"""
+Reserved keywords in respective languages
+"""
+
+# More listed here: http://www.binpress.com/tutorial/objective-c-reserved-keywords/43
+OBJC_RESERVED_MAPPINGS = {
+    "auto": "isAuto",
+    "default": "isDefault",
+    "description": "theDescription",
+    "id": "theID",
+    "register": "theRegister",
+    "restrict": "shouldRestrict",
+    "super": "isSuper",
+    "volatile": "isVolatile",
+    "int": "isInt",
+    "long": "isLong"
+}
+
+# More listed here: https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/doc/uid/TP40014097-CH30-ID412
+SWIFT_RESERVED_MAPPINGS = {
+    "class": "_class",
+    "func": "_func",
+    "init": "_init"
+}

--- a/signals/generators/ios/reserved_mappings.py
+++ b/signals/generators/ios/reserved_mappings.py
@@ -1,7 +1,6 @@
 """
 Reserved keywords in respective languages
 """
-
 # More listed here: http://www.binpress.com/tutorial/objective-c-reserved-keywords/43
 OBJC_RESERVED_MAPPINGS = {
     "auto": "isAuto",
@@ -19,5 +18,16 @@ OBJC_RESERVED_MAPPINGS = {
 SWIFT_RESERVED_MAPPINGS = {
     "class": "_class",
     "func": "_func",
-    "init": "_init"
+    "init": "_init",
+    "id": "theID"
+    # "auto": "isAuto",
+    # "default": "isDefault",
+    # "description": "theDescription",
+    # "id": "theID",
+    # "register": "theRegister",
+    # "restrict": "shouldRestrict",
+    # "super": "isSuper",
+    # "volatile": "isVolatile",
+    # "int": "isInt",
+    # "long": "isLong"
 }

--- a/signals/generators/ios/swift/template.py
+++ b/signals/generators/ios/swift/template.py
@@ -1,6 +1,6 @@
 import shutil
 from signals.generators.base.base_template import BaseTemplate
-from signals.generators.ios.conversion import sanitize_field_name, get_proper_name
+from signals.generators.ios.conversion import SwiftConverter
 from signals.generators.ios.swift.template_methods import SwiftTemplateMethods
 from signals.parser.fields import Field
 
@@ -20,9 +20,9 @@ class SwiftTemplate(BaseTemplate):
             'project_name': self.project_name,
             'VIDEO_FIELD': Field.VIDEO,
             'IMAGE_FIELD': Field.IMAGE,
-            'get_proper_name': get_proper_name,
+            'get_proper_name': SwiftConverter.get_proper_name,
             'request_objects': self.get_request_objects(self.schema.data_objects),
-            'sanitize_field_name': sanitize_field_name,
+            'sanitize_field_name': SwiftConverter.sanitize_field_name,
         })
 
     def copy_data_models(self):

--- a/signals/generators/ios/swift/template_methods.py
+++ b/signals/generators/ios/swift/template_methods.py
@@ -1,4 +1,4 @@
-from signals.generators.ios.conversion import SwiftConverter.get_proper_name
+from signals.generators.ios.conversion import SwiftConverter
 from signals.generators.ios.ios_template_methods import iOSTemplateMethods
 from signals.generators.ios.swift.parameters import SwiftParameter
 from signals.parser.api import GetAPI

--- a/signals/generators/ios/swift/template_methods.py
+++ b/signals/generators/ios/swift/template_methods.py
@@ -1,4 +1,4 @@
-from signals.generators.ios.conversion import get_proper_name
+from signals.generators.ios.conversion import SwiftConverter.get_proper_name
 from signals.generators.ios.ios_template_methods import iOSTemplateMethods
 from signals.generators.ios.swift.parameters import SwiftParameter
 from signals.parser.api import GetAPI
@@ -46,7 +46,7 @@ class SwiftTemplateMethods(iOSTemplateMethods):
         attribute_mapping_string = ""
         for index, field in enumerate(fields):
             leading_comma = '' if index == 0 else ', '
-            swift_variable_name = get_proper_name(field.name)
+            swift_variable_name = SwiftConverter.get_proper_name(field.name)
             attribute_mapping_string += '{}"{}": "{}"'.format(leading_comma, field.name, swift_variable_name)
         return attribute_mapping_string
 
@@ -54,7 +54,7 @@ class SwiftTemplateMethods(iOSTemplateMethods):
     def create_parameter_signature(parameters):
         method_parts = []
         for index, method_field in enumerate(parameters):
-            swift_variable_name = get_proper_name(method_field.name)
+            swift_variable_name = SwiftConverter.get_proper_name(method_field.name)
             parameter_signature = "{}: {}".format(swift_variable_name, method_field.swift_type)
 
             method_parts.append(parameter_signature)

--- a/tests/generators/ios/objc/test_template.py
+++ b/tests/generators/ios/objc/test_template.py
@@ -4,7 +4,7 @@ import unittest
 from datetime import datetime
 from jinja2 import PackageLoader
 from jinja2 import Environment
-from signals.generators.ios.conversion import sanitize_field_name, get_proper_name
+from signals.generators.ios.conversion import ObjectiveCConverter
 from signals.generators.ios.objc.template import ObjectiveCTemplate
 from signals.generators.ios.objc.template_methods import ObjectiveCTemplateMethods
 from signals.parser.fields import Relationship, Field
@@ -27,8 +27,8 @@ class TemplateTestCase(unittest.TestCase):
             template = self.jinja2_environment.get_template(template_name)
             # Registers all methods in template_methods.py with jinja2 for use
             context.update({name: method for name, method in getmembers(ObjectiveCTemplateMethods, isfunction)})
-            context.update({'get_proper_name': get_proper_name,
-                            'sanitize_field_name': sanitize_field_name
+            context.update({'get_proper_name': ObjectiveCConverter.get_proper_name,
+                            'sanitize_field_name': ObjectiveCConverter.sanitize_field_name
                             })
             template_output = template.render(**context)
             expected_template_out = expected_template_file.read()
@@ -222,7 +222,7 @@ class TemplateTestCase(unittest.TestCase):
         })
         self.assertTemplateEqual('entity_mapping.j2', 'EntityMapping.m', {
             'data_object': data_object,
-            'sanitize_field_name': sanitize_field_name
+            'sanitize_field_name': ObjectiveCConverter.sanitize_field_name
         })
 
     def test_relationship_mapping_template(self):
@@ -263,7 +263,7 @@ class TemplateTestCase(unittest.TestCase):
             'today': datetime.today(),
             'endpoints': URL.URL_ENDPOINTS.keys(),
             'request_objects': ObjectiveCTemplate.get_request_objects(schema.data_objects),
-            'sanitize_field_name': sanitize_field_name
+            'sanitize_field_name': ObjectiveCConverter.sanitize_field_name
         }, expected_context=(
             datetime.today().strftime('%m/%d/%Y'),
         ))

--- a/tests/generators/ios/swift/test_template.py
+++ b/tests/generators/ios/swift/test_template.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from datetime import datetime
 from jinja2 import Environment, PackageLoader
-from signals.generators.ios.conversion import get_proper_name, sanitize_field_name
+from signals.generators.ios.conversion import SwiftConverter
 from signals.generators.ios.swift.template import SwiftTemplate
 from signals.generators.ios.swift.template_methods import SwiftTemplateMethods
 from signals.parser.api import GetAPI, PatchAPI, PostAPI
@@ -26,8 +26,8 @@ class SwiftTemplateTestCase(unittest.TestCase):
             template = self.jinja2_environment.get_template(template_name)
             # Registers all methods in template_methods.py with jinja2 for use
             context.update({name: method for name, method in getmembers(SwiftTemplateMethods, isfunction)})
-            context.update({'get_proper_name': get_proper_name,
-                            'sanitize_field_name': sanitize_field_name
+            context.update({'get_proper_name': SwiftConverter.get_proper_name,
+                            'sanitize_field_name': SwiftConverter.sanitize_field_name
                             })
             template_output = template.render(**context)
             expected_template_out = expected_template_file.read()
@@ -221,7 +221,7 @@ class SwiftTemplateTestCase(unittest.TestCase):
         })
         self.assertTemplateEqual('entity_mapping.j2', 'EntityMapping.swift', {
             'data_object': data_object,
-            'sanitize_field_name': sanitize_field_name
+            'sanitize_field_name': SwiftConverter.sanitize_field_name
         })
 
     def test_relationship_mapping_template(self):
@@ -250,7 +250,7 @@ class SwiftTemplateTestCase(unittest.TestCase):
             'today': datetime.today(),
             'endpoints': URL.URL_ENDPOINTS.keys(),
             'request_objects': SwiftTemplate.get_request_objects(schema.data_objects),
-            'sanitize_field_name': sanitize_field_name
+            'sanitize_field_name': SwiftConverter.sanitize_field_name
         }, expected_context=(
             datetime.today().strftime('%m/%d/%Y'),
         ))

--- a/tests/generators/ios/test_conversion.py
+++ b/tests/generators/ios/test_conversion.py
@@ -1,11 +1,16 @@
 import unittest
-from signals.generators.ios.conversion import python_to_objc_variable, sanitize_field_name, get_proper_name
+from signals.generators.ios.conversion import ObjectiveCConverter
 
+
+format_name = ObjectiveCConverter.format_name
+sanitize_field_name = ObjectiveCConverter.sanitize_field_name
+get_proper_name = ObjectiveCConverter.get_proper_name
 
 class ConversionTestCase(unittest.TestCase):
-    def test_python_to_objc_variable(self):
-        self.assertEqual(python_to_objc_variable("verbose_description"), "verboseDescription")
-        self.assertEqual(python_to_objc_variable("verbose_description", capitalize_first=True), "VerboseDescription")
+    
+    def format_name(self):
+        self.assertEqual(format_name("verbose_description"), "verboseDescription")
+        self.assertEqual(format_name("verbose_description", capitalize_first=True), "VerboseDescription")
 
     def test_sanitize_field_name(self):
         self.assertEqual(sanitize_field_name("description"), "theDescription")


### PR DESCRIPTION
Since Objective-C and Swift have different reserved keywords, I have decided to factor out the functions in `conversion.py` into `@classmethods`. The conversion methods are defined under the `BaseConverter` class. `ObjectiveCConverter` and `SwiftConverter` inherits from `BaesConverter` and methods such as `sanitize_field_names` and `get_proper_name` will convert field names to appropriate names in target language based on their respective mappings defined in `reserved_mappings.py`, in which keywords such as `long` and `int` that causes compilation error in Objective-C are now added. Of course, methods defined in the base class can be overridden to generate different format. I have also decided to have `get_proper_name` in `ios_template_methods.py` to convert field names based on Objective-C's reserved mappings because the doc states that the iOS generator currently assumes users to be using Objective-C. However, with this more generalized approach to convert names for iOS code, it should now be easier to add the ability to output Swift templates in the future. Tests were also edited to accommodate the new changes.
